### PR TITLE
Template changes for publisher list

### DIFF
--- a/ckanext/datagovuk/templates/organization/snippets/info.html
+++ b/ckanext/datagovuk/templates/organization/snippets/info.html
@@ -1,0 +1,10 @@
+{% if organization and h.check_access('organization_update', {'id':organization.id }) %}
+  <section class="module module-narrow package-info">
+    <h2 class="module-heading"><i class="fa fa-sitemap"></i> {{ _("Edit Organization") }}</h2>
+    <ul class="list-unstyled nav nav-simple">
+      <li class="nav-item{% if action == 'edit' %} active{% endif %}">
+        {% link_for _("Edit Organization"), controller='organization', action='edit', id=organization.name %}
+      </li>
+    </ul>
+  </section>
+{% endif %}

--- a/ckanext/datagovuk/templates/organization/snippets/organization_item.html
+++ b/ckanext/datagovuk/templates/organization/snippets/organization_item.html
@@ -1,0 +1,32 @@
+{% set url = h.url_for(organization.type ~ '_read', action='read', id=organization.name) %}
+{% block item %}
+<li class="media-item" style="width:91%;">
+  {% block item_inner %}
+  {% block image %}{% endblock image %}
+  {% block title %}
+    <h3 class="media-heading">{{ organization.display_name }}</h3>
+  {% endblock %}
+  {% block description %}{% endblock description %}
+  {% block datasets %}
+    {% if organization.package_count %}
+      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.package_count).format(num=organization.package_count) }}</strong>
+    {% else %}
+      <span class="count">{{ _('0 Datasets') }}</span>
+    {% endif %}
+  {% endblock %}
+  {% block capacity %}
+    {% if show_capacity and organization.capacity %}
+    <p><span class="label label-default">{{ h.roles_translated().get(organization.capacity, organization.capacity) }}</span></p>
+    {% endif %}
+  {% endblock %}
+  {% block link %}
+  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
+    <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
+  </a>
+  {% endblock %}
+  {% endblock %}
+</li>
+{% endblock %}
+{% if position is divisibleby 3 %}
+  <li class="clearfix js-hide"></li>
+{% endif %}

--- a/ckanext/datagovuk/templates/snippets/organization.html
+++ b/ckanext/datagovuk/templates/snippets/organization.html
@@ -1,0 +1,32 @@
+  {% set truncate = truncate or 0 %}
+  {% set url = h.url_for(organization.type + '_read', id=organization.name, ) %}
+
+    {% block info %}
+    <div class="module module-narrow module-shallow context-info">
+      {% if has_context_title %}
+        <h2 class="module-heading"><i class="fa fa-building-o"></i> {{ _('Organization') }}</h2>
+      {% endif %}
+      <section class="module-content">
+        {% block inner %}
+        {% block image %}{% endblock image %}
+        {% block heading %}
+        <h1 class="heading" style="word-wrap: initial;">{{ organization.title or organization.name }}
+          {% if organization.state == 'deleted' %}
+            [{{ _('Deleted') }}]
+          {% endif %}
+        </h1>
+        {% endblock %}
+        {% block description %}{% endblock description %}
+          {% block nums %}
+          <div class="nums">
+            <dl>
+              <dt>{{ _('Datasets') }}</dt>
+              <dd>{{ h.SI_number_span(organization.package_count) }}</dd>
+            </dl>
+          </div>
+          {% endblock %}
+          {% block follow %}{% endblock follow %}
+        {% endblock %}
+      </section>
+    </div>
+    {% endblock %}


### PR DESCRIPTION
Removes the logo for publishers, and just puts them one on a line.  Also
removes the same logo from the dataset detail page.

Before:
<img width="768" alt="publishers_-_dgu" src="https://user-images.githubusercontent.com/118063/40354214-3cf9c6ce-5dab-11e8-8834-2e085976fb7a.png">

After:
<img width="746" alt="publishers_-_dgu-2" src="https://user-images.githubusercontent.com/118063/40354329-79bc3416-5dab-11e8-9813-340a1915a252.png">

