### PR TITLE
Rename org paths

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -104,7 +104,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     def after_map(self, route_map):
         # Deletes all the organization routes
-        delete_routes_by_path_startswtih(route_map, '/organization')
+        delete_routes_by_path_startswith(route_map, '/organization')
 
         # Recreates the organization routes with /publisher instead.
         with SubMapper(route_map, controller='organization') as m:
@@ -145,7 +145,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     import ckanext.datagovuk.ckan_patches  # import does the monkey patching
 
-def delete_routes_by_path_startswtih(map, path_startswith):
+def delete_routes_by_path_startswith(map, path_startswith):
     """
     This function will remove from the routing map any
     path that starts with the provided argument (/ required).

--- a/ckanext/datagovuk/tests/test_paths.py
+++ b/ckanext/datagovuk/tests/test_paths.py
@@ -1,0 +1,11 @@
+import ckan.plugins.toolkit as toolkit
+import ckanext.datagovuk.plugin as plugin
+
+def test_publisher_path_exists():
+    path = toolkit.url_for('publisher_read', action='read', id='cabinet-office')
+    assert(path == '/publisher/cabinet-office')
+
+def test_organization_path_redirects():
+    path = toolkit.url_for('organization_read', action='read', id='cabinet-office')
+    assert(path == '/publisher/cabinet-office')
+

--- a/ckanext/datagovuk/tests/test_paths.py
+++ b/ckanext/datagovuk/tests/test_paths.py
@@ -1,11 +1,11 @@
 import ckan.plugins.toolkit as toolkit
 import ckanext.datagovuk.plugin as plugin
 
-def test_publisher_path_exists():
-    path = toolkit.url_for('publisher_read', action='read', id='cabinet-office')
+def test_read_path():
+    path = toolkit.url_for('organization_read', id='cabinet-office')
     assert(path == '/publisher/cabinet-office')
 
-def test_organization_path_redirects():
-    path = toolkit.url_for('organization_read', action='read', id='cabinet-office')
-    assert(path == '/publisher/cabinet-office')
+def test_edit_path():
+    path = toolkit.url_for('organization_edit', id='cabinet-office')
+    assert(path == '/publisher/edit/cabinet-office')
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+nosetests --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests


### PR DESCRIPTION

Currently all of the publisher routes look like /organization, and this is wrong on at least 2 different levels.  This PR removes all of the routes for /organization* and replaces them with /publisher* so that any requests as follows will resolve properly....

```
url_for('organization_read', id='cabinet-office')
--> /publisher/cabinet-office
```

It also introduces some tests, and a helpful script (./run-tests.sh) which will save having to remember the ultimately forgetful incantation to launch nosetests.






See https://trello.com/c/JzzuMatU/271-overwrite-organization-route-with-publisher-in-ckan
