### PR TITLE
Fix the travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 sudo: required
 python:
-    - "2.6"
     - "2.7"
-env: PGVERSION=9.1
+addons:
+  postgresql: "9.5"
 install:
     - bash bin/travis-build.bash
     - pip install coveralls

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -3,4 +3,5 @@
 echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
 sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 sudo service jetty restart
-nosetests --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests
+sleep 10
+nosetests --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests ckanext/datagovuk/tests


### PR DESCRIPTION
Fixes (and enables) Travis for running the ckanext-datagovuk tests.

Has to update CKAN's psycopg2 dependency for a newer version (not quite sure why this hasn't bitten us with ansible yet) with judicious use of 

```
cd ckan 
.... some stuff  ....
sed -i -e 's/psycopg2==2.4.5/psycopg2==2.7.3.2/g' requirements.txt
```