### PR TITLE
Remove homepage search and other homepage clutter

### DIFF
--- a/ckanext/datagovuk/templates/home/index.html
+++ b/ckanext/datagovuk/templates/home/index.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block primary_content %}
+  {% snippet "home/layout.html" %}
+{% endblock %}
+

--- a/ckanext/datagovuk/templates/home/layout.html
+++ b/ckanext/datagovuk/templates/home/layout.html
@@ -1,0 +1,12 @@
+<div role="main" class="hero">
+  <div class="container">
+    <div class="row row1">
+      <div class="span6 col1">
+        {% block promoted %}
+          {% snippet 'home/snippets/promoted.html' %}
+        {% endblock %}
+      </div>
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
Further to card https://trello.com/c/TwLQmz1L/243-remove-search-bar-from-header-s, there was also a search box on the homepage.

Also gives us a template file to customise for further homepage modifications.