### PR TITLE
Show an upload option if organogram appears in title

### DIFF
--- a/ckanext/datagovuk/helpers.py
+++ b/ckanext/datagovuk/helpers.py
@@ -108,3 +108,6 @@ def themes():
     }
     return themes_dict
 
+def activate_upload(pkg):
+    return 'organogram' in pkg.get('title', '').lower()
+

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -141,7 +141,11 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     # ITemplateHelpers
 
     def get_helpers(self):
-        return {'themes': ckanext.datagovuk.helpers.themes}
+        import ckanext.datagovuk.helpers as h
+        return {
+            'themes': h.themes,
+            'activate_upload': h.activate_upload
+        }
 
     import ckanext.datagovuk.ckan_patches  # import does the monkey patching
 

--- a/ckanext/datagovuk/templates/package/snippets/resource_form.html
+++ b/ckanext/datagovuk/templates/package/snippets/resource_form.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% block basic_fields_url %}
+  {% set is_upload = (data.url_type == 'upload') %}
+  {{ form.image_upload(data, errors, field_url='url', field_upload='upload', field_clear='clear_upload',
+      is_upload_enabled=h.uploads_enabled() and h.activate_upload(data), is_url=data.url and not is_upload, is_upload=is_upload,
+      upload_label=_('Data'), url_label=_('URL'), placeholder=_('http://example.com/external-data.csv')) }}
+{% endblock basic_fields_url %}


### PR DESCRIPTION
As we need to explore options for allowing file uploads when users are
publishing organogram datasets, we should only show the option when
we can determine it is such a dataset.

Initially, we have no mechanism for starting the process of creating an
organogram dataset, and so we will currently rely on the word 'organogram'
appearing in the dataset title.  This should change once we have a more
accurate way of initiating the process.