### PR TITLE
Add links to view and add harvest sources by publisher

### DIFF
--- a/ckanext/datagovuk/templates/organization/read.html
+++ b/ckanext/datagovuk/templates/organization/read.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block page_primary_action %}
+  {% if h.check_access('package_create', {'owner_org': c.group_dict.id}) %}
+    {% link_for _('Add Dataset'), controller='package', action='new', group=c.group_dict.id, class_='btn btn-primary', icon='plus-square' %}
+  {% endif %}
+  {% if h.check_access('harvest_source_create') %}
+    <a href="{{ h.url_for('harvest_new', group=c.group_dict.id) }}" class="btn btn-primary"><i class="fa fa-plus-square"></i> {{ _('Add Harvest Source') }}</a>
+  {% endif %}
+
+{% endblock %}

--- a/ckanext/datagovuk/templates/organization/read_base.html
+++ b/ckanext/datagovuk/templates/organization/read_base.html
@@ -1,0 +1,10 @@
+{% ckan_extends %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon('organization_read', _('Datasets'), id=c.group_dict.name) }}
+  {% if h.check_access('harvest_source_create') %}
+    {{ h.build_nav_icon('harvest_org_list', _('Harvest Sources'), id=c.group_dict.name) }}
+  {% endif %}
+  {{ h.build_nav_icon('organization_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
+  {{ h.build_nav_icon('organization_about', _('About'), id=c.group_dict.name) }}
+{% endblock %}


### PR DESCRIPTION
This add the links too view/create harvest sources from publisher pages.  As commented in Trello card, some work will need to be done to get the harvest sources by publisher page displaying correctly.

https://trello.com/c/2AMXSoAx/274-add-harvester-tab-to-organisation-page