### PR TITLE
When resetting all users' passwords we need the ID

### DIFF
--- a/ckanext/datagovuk/lib/cli.py
+++ b/ckanext/datagovuk/lib/cli.py
@@ -33,10 +33,10 @@ class PasswordResetsCommand(CkanCommand):
 
         with open(output_file, 'wb') as f:
             writer = csv.writer(f)
-            writer.writerow(['email-address', 'reset-key'])
+            writer.writerow(['id', 'email-address', 'reset-key'])
 
             for user in model.User.all():
                 create_reset_key(user)
                 user.save()
 
-                writer.writerow([user.email, user.reset_key])
+                writer.writerow([user.id, user.email, user.reset_key])


### PR DESCRIPTION
As the password reset URL is /user/ID?key=KEY the CSV export (after reset)
should contain the ID of the user. Now it does.