### PR TITLE
Remove calls to social media links

### DIFF
--- a/ckanext/datagovuk/templates/package/read_base.html
+++ b/ckanext/datagovuk/templates/package/read_base.html
@@ -1,0 +1,4 @@
+{% ckan_extends %}
+
+{% block package_social %}
+{% endblock %}

--- a/ckanext/datagovuk/templates/package/resource_read.html
+++ b/ckanext/datagovuk/templates/package/resource_read.html
@@ -1,0 +1,4 @@
+{% ckan_extends %}
+
+{% block resource_license %}
+{% endblock %}

--- a/ckanext/datagovuk/templates/revision/read_base.html
+++ b/ckanext/datagovuk/templates/revision/read_base.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+{% block package_social %}
+{% endblock %}


### PR DESCRIPTION
https://trello.com/c/BuEzsSsc/292-remove-social-media-buttons-from-new-ckan

We don't want users to see the Twitter/Google etc links. It's not possible to override the social media module itself so this PR removes the calls to it instead.