### PR TITLE
Remove domain from URL

### DIFF
--- a/ckanext/datagovuk/templates/organization/snippets/organization_form.html
+++ b/ckanext/datagovuk/templates/organization/snippets/organization_form.html
@@ -1,0 +1,20 @@
+{% ckan_extends %}
+
+  {% block basic_fields %}
+    {% set attrs = {'data-module': 'slug-preview-target'} %}
+    {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Organization'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
+
+    {# Perhaps these should be moved into the controller? #}
+    {% set prefix = h.url_for(controller='organization', action='read', id='') %}
+    {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': "/", 'data-module-placeholder': '<organization>'} %}
+
+    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-organization'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+
+    {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my organization...'), value=data.description, error=errors.description) }}
+
+    {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+    {% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
+
+  {% endblock %}

--- a/ckanext/datagovuk/templates/organization/snippets/organization_form.html
+++ b/ckanext/datagovuk/templates/organization/snippets/organization_form.html
@@ -6,7 +6,9 @@
 
     {# Perhaps these should be moved into the controller? #}
     {% set prefix = h.url_for(controller='organization', action='read', id='') %}
-    {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': "/", 'data-module-placeholder': '<organization>'} %}
+    {% set domain = h.url_for(controller='organization', action='read', id='', qualified=true) %}
+    {% set domain = domain|replace("http://", "")|replace("https://", "") %}
+    {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<publisher>'} %}
 
     {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-organization'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
 

--- a/ckanext/datagovuk/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_basic_fields.html
@@ -4,3 +4,8 @@
 {# This block is located between the Title and Description in the default CKAN templates #}
 {% endblock %}
 
+{% block package_basic_fields_url %}
+  {% set prefix = h.url_for(controller='package', action='read', id='') %}
+  {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': '/', 'data-module-placeholder': '<dataset>'} %}
+  {{ form.prepend('name', id='field-name', label=_('URL'), prepend=prefix, placeholder=_('eg. my-dataset'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+{% endblock %}


### PR DESCRIPTION
https://trello.com/b/a30DSRUe/dgu-q1-doing

This PR removes the default domain from the URL preview when creating datasets. We cannot give a full URL path (eg https://data.gov.uk/.....) as those urls contain a data ID that isn't available to CKAN at creation, but Gurinder advises that URL is still an accurate enough label for the field.

![screen shot 2018-06-06 at 14 33 11](https://user-images.githubusercontent.com/31649453/41041317-9965bef8-6996-11e8-901f-c15ad0257b3c.png)

It also modifies the preview url for creating a new publisher - since this would be accessed in ckan the default domain is appropriate, but the slug preview name is now "publisher" instead of "organization".

We cannot easily modify the harvester url preview but the default state is appropriate.