### PR TITLE
Remove the resource description field

### DIFF
--- a/ckanext/datagovuk/templates/package/snippets/resource_form.html
+++ b/ckanext/datagovuk/templates/package/snippets/resource_form.html
@@ -32,3 +32,6 @@
 {% block add_button %}
 <button class="btn btn-primary" name="save" value="go-dataset-complete" type="submit">{{ _('Publish') }}</button>
 {% endblock %}
+
+{% block basic_fields_description %}
+{% endblock %}


### PR DESCRIPTION
https://trello.com/c/s8sPyRS3/301-hide-description-field-when-adding-or-editing-a-datafile