### PR TITLE
Add licence-custom field

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -41,6 +41,8 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         schema.update({
             'theme-primary': [toolkit.get_validator('valid_theme'),
                               toolkit.get_validator('ignore_missing'),
+                              toolkit.get_converter('convert_to_extras')],
+            'licence-custom': [toolkit.get_validator('ignore_missing'),
                               toolkit.get_converter('convert_to_extras')]
         })
         for contact_key in ['contact-name', 'contact-email', 'contact-phone', 'foi-name', 'foi-email', 'foi-web', 'foi-phone']:
@@ -71,6 +73,8 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         schema = schema_defs.show_package_schema(default_show_package_schema())
         schema.update({
             'theme-primary': [toolkit.get_converter('convert_from_extras'),
+                              toolkit.get_validator('ignore_missing')],
+            'licence-custom': [toolkit.get_converter('convert_from_extras'),
                               toolkit.get_validator('ignore_missing')]
         })
         for contact_key in ['contact-name', 'contact-email', 'contact-phone', 'foi-name', 'foi-email', 'foi-web', 'foi-phone']:

--- a/ckanext/datagovuk/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_basic_fields.html
@@ -14,14 +14,19 @@
   {{ form.prepend('name', id='field-name', label=_('URL'), prepend=prefix, placeholder=_('eg. my-dataset'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
 {% endblock %}
 
-{% block package_basic_fields_description %}
-  {{ form.markdown('notes', id='field-notes', label=_('Description'), value=data.notes, error=errors.notes) }}
+{% block package_basic_fields_license %}
+{{ super() }}
+<div class="control-group">
+  <label class="control-label" for="licence-custom">{{ _("Licence Information") }}</label>
+  <div class="controls">
+    <input type="text" id="field-licence-custom" name="licence-custom" value="{{ data.get('licence-custom','') }}">
+  </div>
+</div>
 {% endblock %}
 
 {% block package_metadata_fields_visibility %}
-      <input type="hidden" name="private" value="False">
+  <input type="hidden" name="private" value="False">
 {% endblock %}
 
 {% block package_basic_fields_tags %}
 {% endblock %}
-


### PR DESCRIPTION
This adds a `licence-custom` field so that we can display an optional "Licence Information" field on the dataset form.