### PR TITLE
Remove groups tab

### DIFF
--- a/ckanext/datagovuk/templates/package/read_base.html
+++ b/ckanext/datagovuk/templates/package/read_base.html
@@ -2,3 +2,8 @@
 
 {% block package_social %}
 {% endblock %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
+  {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
+{% endblock %}


### PR DESCRIPTION
https://trello.com/c/4CoDfb8M/366-remove-groups-tab-when-viewing-datasets