### PR TITLE
Add /healthcheck endpoint

### DIFF
--- a/ckanext/datagovuk/controllers/healthcheck.py
+++ b/ckanext/datagovuk/controllers/healthcheck.py
@@ -1,0 +1,5 @@
+from ckan.controllers.group import GroupController
+
+class HealthcheckController(GroupController):
+    def healthcheck(self):
+        return "OK"

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -114,10 +114,12 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     def before_map(self, route_map):
         user_controller = 'ckanext.datagovuk.controllers.user:UserController'
+        healthcheck_controller = 'ckanext.datagovuk.controllers.healthcheck:HealthcheckController'
         route_map.connect('register',
                           '/user/register',
                           controller=user_controller,
                           action='register')
+        route_map.connect('/healthcheck', controller=healthcheck_controller, action='healthcheck')
         return route_map
 
     def after_map(self, route_map):


### PR DESCRIPTION
For https://trello.com/c/4OwURSFn/329-add-ckan-healthcheck-endpoint

We add this endpoint so that eventually we can monitor uptime metrics. See [documentation](https://docs.publishing.service.gov.uk/manual/uptime-metrics.html#header) for further information about GOV.UK's uptime monitoring service.