### PR TITLE
Add a script to push release branch and tag on master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,13 @@ install:
 script: sh bin/travis-run.sh
 after_success:
     - coveralls
+branches:
+  except:
+    - /release_\d+/
+    - release
+deploy:
+  # Create a release tag for successful master builds
+  - provider: script
+    script: bash bin/travis-push.sh
+    on:
+      branch: master

--- a/bin/travis-push.sh
+++ b/bin/travis-push.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+git config --local user.name "Travis CI"
+git config --local user.email "govuk-ci@users.noreply.github.com"
+git tag "release_${TRAVIS_BUILD_NUMBER}"
+git push https://govuk-ci:${GOVUK_CI_TOKEN}@github.com/${TRAVIS_REPO_SLUG} "release_${TRAVIS_BUILD_NUMBER}"
+git push https://govuk-ci:${GOVUK_CI_TOKEN}@github.com/${TRAVIS_REPO_SLUG} HEAD:refs/heads/release -f


### PR DESCRIPTION
In GOV.UK we tag the build with `release_${BUILD_NUMBER}` and also update the `release` branch. We also need to stop Travis building these branches and tags when it notices them.

I decided not to port this to Jenkins yet due to the complexity of the dependencies it requires (CKAN, Solr etc)