### PR TITLE
Remove display of publisher usernames

### DIFF
--- a/ckanext/datagovuk/templates/organization/read_base.html
+++ b/ckanext/datagovuk/templates/organization/read_base.html
@@ -5,6 +5,5 @@
   {% if h.check_access('harvest_source_create') %}
     {{ h.build_nav_icon('harvest_org_list', _('Harvest Sources'), id=c.group_dict.name) }}
   {% endif %}
-  {{ h.build_nav_icon('organization_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
   {{ h.build_nav_icon('organization_about', _('About'), id=c.group_dict.name) }}
 {% endblock %}

--- a/ckanext/datagovuk/templates/package/read_base.html
+++ b/ckanext/datagovuk/templates/package/read_base.html
@@ -5,5 +5,4 @@
 
 {% block content_primary_nav %}
   {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
-  {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
 {% endblock %}

--- a/ckanext/datagovuk/templates/user/list.html
+++ b/ckanext/datagovuk/templates/user/list.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% set user_is_sysadmin = h.check_access('sysadmin') %}
+
+{% block primary_content %}
+{% if user_is_sysadmin %}
+  {{ super() }}
+{% else %}
+  {{_('You must be a system administrator to view the user list')}}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Removes the public display of publisher usernames (i.e. their email address) by removing the organisation activity feed, dataset activity feed and restricting the 'all users' list to sysadmins only.

https://trello.com/c/cCjocYlo/367-remove-the-public-display-of-publisher-email-addresses