### PR TITLE
Revert "Add a script to push release branch and tag on master build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,3 @@ install:
 script: sh bin/travis-run.sh
 after_success:
     - coveralls
-branches:
-  except:
-    - /release_\d+/
-    - release
-deploy:
-  # Create a release tag for successful master builds
-  - provider: script
-    script: bash bin/travis-push.sh
-    on:
-      branch: master

--- a/bin/travis-push.sh
+++ b/bin/travis-push.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-
-git config --local user.name "Travis CI"
-git config --local user.email "govuk-ci@users.noreply.github.com"
-git tag "release_${TRAVIS_BUILD_NUMBER}"
-git push https://govuk-ci:${GOVUK_CI_TOKEN}@github.com/${TRAVIS_REPO_SLUG} "release_${TRAVIS_BUILD_NUMBER}"
-git push https://govuk-ci:${GOVUK_CI_TOKEN}@github.com/${TRAVIS_REPO_SLUG} HEAD:refs/heads/release -f


### PR DESCRIPTION
Reverts alphagov/ckanext-datagovuk#59

This isn't working so I'm going to revert while we fix it, rather than have "failing" builds.