### PR TITLE
Fix alignment of 'schema/vocabulary' field and label

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -44,3 +44,16 @@ a.btn .icon-briefcase {
   height:14px;
   background-position: 36px 17px;
 }
+
+.form-horizontal .control-label {
+  width: 140px;
+}
+
+.form-horizontal .controls {
+  margin-left: 145px;
+}
+
+.controls select {
+  width: 100%;
+  height: 120px;
+}


### PR DESCRIPTION
Before:
<img width="467" alt="screen_shot_2018-06-13_at_16 51 55" src="https://user-images.githubusercontent.com/6329861/41533395-862cde74-72f2-11e8-8a5d-c234e1b89301.png">
After:
<img width="697" alt="screen shot 2018-06-18 at 12 21 12" src="https://user-images.githubusercontent.com/6329861/41533400-8bb2950a-72f2-11e8-99a4-c4420c7295fb.png">


https://trello.com/c/w1FlAoGh/375-fix-schema-vocabulary-label-alignment