### PR TITLE
Fix typo in contact phone field name

### DIFF
--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -59,7 +59,7 @@
 <div class="control-group">
   <label class="control-label" for="contact-phone">{{ _("Contact Phone") }}</label>
   <div class="controls">
-    <input type="text" id="field-contact-phone" name="foi-contact-phone" value="{{ data.get('contact-phone','') }}">
+    <input type="text" id="field-contact-phone" name="contact-phone" value="{{ data.get('contact-phone','') }}">
   </div>
 </div>
 <div class="control-group">


### PR DESCRIPTION
This field wasn't saving into the database