### PR TITLE
Allow users to login with their username or email

### DIFF
--- a/ckanext/datagovuk/controllers/user.py
+++ b/ckanext/datagovuk/controllers/user.py
@@ -1,7 +1,22 @@
 from ckan.controllers.user import UserController
+import ckan.lib.base as base
+import ckan.model as model
+import ckan.logic as logic
+import ckan.logic.schema as schema
+import ckan.lib.mailer as mailer
 import ckan.lib.helpers as h
 
 from ckan.common import _, c, request, response
+
+abort = base.abort
+render = base.render
+
+check_access = logic.check_access
+get_action = logic.get_action
+NotFound = logic.NotFound
+NotAuthorized = logic.NotAuthorized
+ValidationError = logic.ValidationError
+UsernamePasswordError = logic.UsernamePasswordError
 
 class UserController(UserController):
     def _new_form_to_db_schema(self):
@@ -31,4 +46,58 @@ class UserController(UserController):
                                  ' do not match.'))
             return password1
         raise ValueError(_('You must provide a password'))
+
+    def request_reset(self):
+        context = {'model': model, 'session': model.Session, 'user': c.user,
+                   'auth_user_obj': c.userobj}
+        data_dict = {'id': request.params.get('user')}
+        try:
+            check_access('request_reset', context)
+        except NotAuthorized:
+            abort(403, _('Unauthorized to request reset password.'))
+
+        if request.method == 'POST':
+            id = request.params.get('user')
+
+            context = {'model': model,
+                       'user': c.user}
+
+            data_dict = {'id': id}
+            user_obj = None
+            try:
+                user_dict = get_action('user_show')(context, data_dict)
+                user_obj = context['user_obj']
+            except NotFound:
+                # Try getting the user by email
+                user_obj = model.User.by_email(id)[0]
+
+                if not user_obj:
+                    # Try searching the user
+                    del data_dict['id']
+                    data_dict['q'] = id
+
+                    if id and len(id) > 2:
+                        user_list = get_action('user_list')(context, data_dict)
+                        if len(user_list) == 1:
+                            del data_dict['q']
+                            data_dict['id'] = user_list[0]['id']
+                            user_dict = get_action('user_show')(context, data_dict)
+                            user_obj = context['user_obj']
+                        elif len(user_list) > 1:
+                            h.flash_error(_('"%s" matched several users') % (id))
+                        else:
+                            h.flash_error(_('No such user: %s') % id)
+                    else:
+                        h.flash_error(_('No such user: %s') % id)
+
+            if user_obj:
+                try:
+                    mailer.send_reset_link(user_obj)
+                    h.flash_success(_('Please check your inbox for '
+                                    'a reset code.'))
+                    h.redirect_to('/')
+                except mailer.MailerException, e:
+                    h.flash_error(_('Could not send reset link: %s') %
+                                  unicode(e))
+        return render('user/request_reset.html')
 

--- a/ckanext/datagovuk/lib/authenticator.py
+++ b/ckanext/datagovuk/lib/authenticator.py
@@ -1,0 +1,34 @@
+import logging
+
+from zope.interface import implements
+from repoze.who.interfaces import IAuthenticator
+
+from ckan.model import User
+from ckan.lib.authenticator import UsernamePasswordAuthenticator
+
+log = logging.getLogger(__name__)
+
+
+class UsernamePasswordAuthenticator(UsernamePasswordAuthenticator):
+    implements(IAuthenticator)
+
+    def authenticate(self, environ, identity):
+        if not ('login' in identity and 'password' in identity):
+            return None
+
+        login = identity['login']
+        user = User.by_name(login)
+        if user is None:
+          user = User.by_email(login)[0]
+
+        if user is None:
+            log.debug('Login failed - username %r not found', login)
+        elif not user.is_active():
+            log.debug('Login as %r failed - user isn\'t active', login)
+        elif not user.validate_password(identity['password']):
+            log.debug('Login as %r failed - password not valid', login)
+        else:
+            return user.name
+
+        return None
+

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -134,6 +134,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             m.connect('/user/logged_in', action='logged_in')
             m.connect('/user/edit', action='edit')
             m.connect('/user/edit/{id:.*}', action='edit')
+            m.connect('/user/reset', action='request_reset')
         route_map.connect('/healthcheck', controller=healthcheck_controller, action='healthcheck')
         return route_map
 

--- a/ckanext/datagovuk/templates/user/request_reset.html
+++ b/ckanext/datagovuk/templates/user/request_reset.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block form %}
+  <form action="" method="post" class="form-inline control-medium">
+    <label for="field-username">{{ _('Username or Email') }}</label>
+    <input id="field-username" name="user" value="" type="text" />
+    {% block form_button %}
+    <button class="btn btn-primary" type="submit" name="reset">{{ _("Request reset") }}</button>
+    {% endblock %}
+  </form>
+{% endblock %}

--- a/ckanext/datagovuk/templates/user/snippets/login_form.html
+++ b/ckanext/datagovuk/templates/user/snippets/login_form.html
@@ -1,0 +1,20 @@
+{% import 'macros/form.html' as form %}
+
+{% set username_error = true if error_summary %}
+{% set password_error = true if error_summary %}
+
+<form action="{{ action }}" method="post" class="form-horizontal">
+  {{ form.errors(errors=error_summary) }}
+
+  {{ form.input('login', label=_("Username or Email"), id='field-login', value="", error=username_error, classes=["control-medium"]) }}
+
+  {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"]) }}
+
+  {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000") }}
+
+  <div class="form-actions">
+    {% block login_button %}
+    <button class="btn btn-primary" type="submit">{{ _('Login') }}</button>
+    {% endblock %}
+  </div>
+</form>


### PR DESCRIPTION
This overrides the default CKAN authenticator to lookup the user by email, if their input is not a valid username.

Also allows passwords to be reset by email, instead of username.

Updates the relevant labels from 'Username' to 'Username or Email'.