### PR TITLE
Update theme form element

### DIFF
--- a/ckanext/datagovuk/helpers.py
+++ b/ckanext/datagovuk/helpers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+import operator
 from ckan.lib.munge import munge_tag
 
 def remove_duplicates_in_a_list(list_):
@@ -108,6 +109,10 @@ def themes():
         "transport": "Transport",
     }
     return themes_dict
+
+def alphabetised_themes():
+    alphabetised_themes = sorted(themes().items(), key=operator.itemgetter(1))
+    return alphabetised_themes
 
 def schemas():
     schemas_dict = {

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -186,6 +186,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             'schemas': h.schemas,
             'split_values': h.split_values,
             'codelist': h.codelist,
+            'alphabetised_themes': h.alphabetised_themes,
         }
 
     import ckanext.datagovuk.ckan_patches  # import does the monkey patching

--- a/ckanext/datagovuk/templates/package/snippets/additional_info.html
+++ b/ckanext/datagovuk/templates/package/snippets/additional_info.html
@@ -3,7 +3,7 @@
 {% block extras %}
   {% if pkg_dict.get('theme-primary','') %}
     <tr>
-      <th scope="row" class="dataset-label">{{ _("Primary Theme") }}</th>
+      <th scope="row" class="dataset-label">{{ _("Theme") }}</th>
       <td class="dataset-details">{{ h.themes()[pkg_dict.get('theme-primary','')] }}</td>
     </tr>
   {% endif %}

--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -12,7 +12,7 @@
 {% block custom_fields %}
 {# This block appears at the bottom of the form, in place of the custom fields in default CKAN #}
 <div class="control-group">
-  <label class="control-label" for="theme-primary">{{ _("Primary Theme") }}</label>
+  <label class="control-label" for="theme-primary">{{ _("Theme") }}</label>
   <div class="controls">
     <select id="field-theme-primary" name="theme-primary" data-module="autocomplete">
       {% for theme_key, theme_val in h.themes().iteritems() %}

--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -15,8 +15,8 @@
   <label class="control-label" for="theme-primary">{{ _("Theme") }}</label>
   <div class="controls">
     <select id="field-theme-primary" name="theme-primary" data-module="autocomplete">
-      {% for theme_key, theme_val in h.themes().iteritems() %}
-        <option value="{{ theme_key }}" {% if data.get('theme-primary', '') == theme_key %}selected="selected"{% endif %}>{{ theme_val }}</option>
+      {% for theme in h.alphabetised_themes() %}
+        <option value="{{ theme[0] }}" {% if data.get('theme-primary', '') == theme[0] %}selected="selected"{% endif %}>{{ theme[1] }}</option>
       {% endfor %}
     </select>
     {% if errors.get('theme-primary', '') %}


### PR DESCRIPTION
For https://trello.com/c/f4LQD6h4/300-update-theme-form-element

* This changes the "Primary Theme" label to "Theme" on the dataset create/edit form as there is no secondary theme (we also update the reference to it on the dataset additional info page):

**Before**
<img width="380" alt="primary-theme-original-label" src="https://user-images.githubusercontent.com/13434452/41594275-c62a705e-73ba-11e8-958c-38e284621e61.png">

**After**
<img width="306" alt="primary-theme-new-label" src="https://user-images.githubusercontent.com/13434452/41594290-cff35ad8-73ba-11e8-971a-c5557a39d5cf.png">

* In order to make it easier for users to find the right theme, we order the values in the "Theme" dropdown alphabetically: 

**Before**
<img width="359" alt="primary-theme-not-sorted" src="https://user-images.githubusercontent.com/13434452/41594349-0d7f56ae-73bb-11e8-9eb2-d263ff23d44b.png">

**After**
<img width="352" alt="primary-theme-sorted" src="https://user-images.githubusercontent.com/13434452/41594358-13e8980c-73bb-11e8-98d0-16d3fe0a25ac.png">
