### PR TITLE
Order form list values alphabetically

### DIFF
--- a/ckanext/datagovuk/helpers.py
+++ b/ckanext/datagovuk/helpers.py
@@ -110,9 +110,9 @@ def themes():
     }
     return themes_dict
 
-def alphabetised_themes():
-    alphabetised_themes = sorted(themes().items(), key=operator.itemgetter(1))
-    return alphabetised_themes
+def alphabetise_dict(dict):
+    alphabetised_dict = sorted(dict.items(), key=operator.itemgetter(1))
+    return alphabetised_dict
 
 def schemas():
     schemas_dict = {

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -186,7 +186,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             'schemas': h.schemas,
             'split_values': h.split_values,
             'codelist': h.codelist,
-            'alphabetised_themes': h.alphabetised_themes,
+            'alphabetise_dict': h.alphabetise_dict,
         }
 
     import ckanext.datagovuk.ckan_patches  # import does the monkey patching

--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -45,8 +45,8 @@
   <label class="control-label" for="codelist">{{ _("Code Lists") }}</label>
   <div class="controls">
     <select multiple id="field-codelist" name="codelist">
-      {% for codelist_id, codelist_name in h.codelist().iteritems() %}
-      <option value="{{ codelist_id }}" {% if data.get('codelist', '') == codelist_id %}selected="selected"{% endif %}>{{ codelist_name.decode("utf8") }}</option>
+      {% for codelist in h.alphabetise_dict(h.codelist()) %}
+        <option value="{{ codelist[0] }}" {% if data.get('codelist', '') == codelist[0] %}selected="selected"{% endif %}>{{ codelist[1] }}</option>
       {% endfor %}
     </select>
     {% if errors.get('codelist', '') %}

--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -30,8 +30,8 @@
   <label class="control-label" for="schema-vocabulary">{{ _("Schema/Vocabulary") }}</label>
   <div class="controls">
     <select multiple id="field-schema-vocabulary" name="schema-vocabulary">
-      {% for schema_id, schema_name in h.schemas().iteritems() %}
-      <option value="{{ schema_id }}" {% if data.get('schema-vocabulary', '') == schema_id %}selected="selected"{% endif %}>{{ schema_name.decode("utf8") }}</option>
+      {% for schema in h.alphabetise_dict(h.schemas()) %}
+        <option value="{{ schema[0] }}" {% if data.get('schema-vocabulary', '') == schema[0] %}selected="selected"{% endif %}>{{ schema[1].decode("utf8") }}</option>
       {% endfor %}
     </select>
     {% if errors.get('schema-vocabulary', '') %}

--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -15,7 +15,7 @@
   <label class="control-label" for="theme-primary">{{ _("Theme") }}</label>
   <div class="controls">
     <select id="field-theme-primary" name="theme-primary" data-module="autocomplete">
-      {% for theme in h.alphabetised_themes() %}
+      {% for theme in h.alphabetise_dict(h.themes()) %}
         <option value="{{ theme[0] }}" {% if data.get('theme-primary', '') == theme[0] %}selected="selected"{% endif %}>{{ theme[1] }}</option>
       {% endfor %}
     </select>


### PR DESCRIPTION
For https://trello.com/c/flpFzetI/377-make-form-lists-show-options-in-alphabetical-order

In order to make it easier for users to find the right option in a form list, we order the values in the "Schema/Vocabulary" and "Code List" form lists alphabetically.

**Schema/Vocabulary - Before**
<img width="384" alt="schema-not-sorted" src="https://user-images.githubusercontent.com/13434452/41599080-f8762da0-73c9-11e8-817d-ab56fefaafab.png">

**Schema/Vocabulary - After**
<img width="390" alt="schema-sorted" src="https://user-images.githubusercontent.com/13434452/41599085-fc2958a0-73c9-11e8-9ee5-9cddc1cd5887.png">

**Code List - Before**
<img width="358" alt="codelist-not-sorted" src="https://user-images.githubusercontent.com/13434452/41599087-ff7607b0-73c9-11e8-9de4-d24e0adbebbc.png">

**Code List - After**
<img width="343" alt="codelist-sorted" src="https://user-images.githubusercontent.com/13434452/41599091-039179a6-73ca-11e8-8981-1af33adeedd1.png">
