### PR TITLE
Add script for incremental import of datasets

### DIFF
--- a/IMPORT.md
+++ b/IMPORT.md
@@ -73,9 +73,17 @@ rsync -L --progress co@co-prod3.dh.bytemark.co.uk:/var/lib/ckan/ckan/dumps_with_
 
        python /vagrant/import/migrate_datasets.py -s datasets.jsonl.gz -o datasets_migrated.jsonl.gz
 
+*. Optional - perform an incremental update by selecting only datasets that have been modified or created since a time, given as a ISO8601 timestamp (e.g. 2018-04-12T17:07:36.284461)
+
+       python /vagrant/import/incremental_update.py -s datasets_migrated.jsonl.gz -o datasets_migrated_incremental.jsonl.gz -t <timestamp>
+
 8. Import the dataset data (takes 4.5 hours on an EC2 t2.medium):
 
        ckanapi load datasets -I datasets_migrated.jsonl.gz -z -p 3 -c /etc/ckan/ckan.ini
+
+   If performing an incremental update, use the incremental migration data only:
+
+       ckanapi load datasets -I datasets_migrated_incremental.jsonl.gz -z -p 3 -c /etc/ckan/ckan.ini
 
 9. Migrate the harvest sources from legacy (takes about 5 minutes):
 

--- a/import/incremental_update.py
+++ b/import/incremental_update.py
@@ -1,0 +1,48 @@
+import argparse
+import json
+import os
+import sys
+import gzip
+import iso8601
+
+from running_stats import Stats
+
+args = None
+stats = Stats()
+
+def process(source, output, timestamp):
+    with gzip.open(source, 'rb') as input_f, \
+            gzip.open(output, 'wb') as output_f:
+        lines = input_f.readlines()
+        for line in lines:
+            dataset = json.loads(line)
+            if dataset['metadata_modified'] >= timestamp:
+                output_f.write(line)
+                stats.add("Dataset updated", dataset["id"])
+            else:
+                stats.add("Dataset not updated", dataset["id"])
+
+    print stats
+    print 'Written %s' % output
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Cleanup the DGU export')
+    parser.add_argument('--source', '-s', dest='source',
+                        help='Specify the location of the source file')
+    parser.add_argument('--output', '-o', dest='output',
+                        help='Specify the location of the output file')
+    parser.add_argument('--timestamp', '-t', dest='timestamp',
+                        help='Specify the timestamp of the last import')
+
+    args = parser.parse_args()
+    if not args.source or not args.output:
+        print "Both source and output files are required\n"
+        print parser.print_help()
+        sys.exit(1)
+
+    if not os.path.exists(args.source):
+        print "Source file {0} could not be found\n".format(args.source)
+        print parser.print_help()
+        sys.exit(1)
+
+    process(args.source, args.output, args.timestamp)


### PR DESCRIPTION
This script allows us to isolate datasets (and datafiles) that have been modified after a specified timestamp. Therefore we can run an incremental import for only those datasets that have changed after the previous dump.

https://trello.com/c/FNPRIk91/384-delta-sync-between-legacy-and-new-ckan

Original PR: https://github.com/alphagov/datagovuk_ckan_deployment/pull/59