### PR TITLE
Remove user dashboard feed

### DIFF
--- a/ckanext/datagovuk/controllers/user.py
+++ b/ckanext/datagovuk/controllers/user.py
@@ -1,7 +1,16 @@
 from ckan.controllers.user import UserController
+import ckan.lib.helpers as h
+
+from ckan.common import _, c, request, response
 
 class UserController(UserController):
     def _new_form_to_db_schema(self):
         from ckanext.datagovuk.schema import user_new_form_schema
         return user_new_form_schema()
 
+    def me(self, locale=None):
+        if not c.user:
+            h.redirect_to(locale=locale, controller='user', action='login',
+                          id=None)
+        user_ref = c.userobj.get_reference_preferred_for_uri()
+        h.redirect_to(locale=locale, controller='user', action='dashboard_datasets')

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -131,6 +131,8 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
                           '/user/register',
                           controller=user_controller,
                           action='register')
+        with SubMapper(route_map, controller=user_controller) as m:
+            m.connect('/user/logged_in', action='logged_in')
         route_map.connect('/healthcheck', controller=healthcheck_controller, action='healthcheck')
         return route_map
 

--- a/ckanext/datagovuk/templates/header.html
+++ b/ckanext/datagovuk/templates/header.html
@@ -23,10 +23,44 @@
 {# Remove the search box from header #}
 {% endblock %}
 
-{% block header_account_log_out_link %}
+{% block header_account_logged %}
+  {% if c.userobj.sysadmin %}
+    <li>
+      <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
+        <i class="fa fa-gavel" aria-hidden="true"></i>
+        <span class="text">{{ _('Admin') }}</span>
+      </a>
+    </li>
+  {% endif %}
   <li>
-    <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
-      {{ _('Log out') }}
+    <a href="{{ h.url_for(controller='user', action='read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
+      {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''), size=22) }}
+      <span class="username">{{ c.userobj.display_name }}</span>
     </a>
   </li>
+  {% set new_activities = h.new_activities() %}
+  <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
+    {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities) %}
+    <a href="{{ h.url_for(controller='user', action='dashboard_datasets') }}" title="{{ notifications_tooltip }}">
+      <i class="fa fa-tachometer" aria-hidden="true"></i>
+      <span class="text">{{ _('Dashboard') }}</span>
+      <span class="badge">{{ new_activities }}</span>
+    </a>
+  </li>
+  {% block header_account_settings_link %}
+    <li>
+      <a href="{{ h.url_for(controller='user', action='edit', id=c.userobj.name) }}" title="{{ _('Edit settings') }}">
+        <i class="fa fa-cog" aria-hidden="true"></i>
+        <span class="text">{{ _('Settings') }}</span>
+      </a>
+    </li>
+  {% endblock %}
+  {% block header_account_log_out_link %}
+    <li>
+      <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
+        {{ _('Log out') }}
+      </a>
+    </li>
+  {% endblock %}
 {% endblock %}
+

--- a/ckanext/datagovuk/templates/user/dashboard.html
+++ b/ckanext/datagovuk/templates/user/dashboard.html
@@ -8,7 +8,6 @@
     <ul class="nav nav-tabs">
       {{ h.build_nav_icon('user_dashboard_datasets', _('My Datasets')) }}
       {{ h.build_nav_icon('user_dashboard_organizations', _('My Organizations')) }}
-      {{ h.build_nav_icon('user_dashboard_groups', _('My Groups')) }}
     </ul>
   </header>
 {% endblock %}

--- a/ckanext/datagovuk/templates/user/dashboard.html
+++ b/ckanext/datagovuk/templates/user/dashboard.html
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+
+{% block page_header %}
+  <header class="module-content page-header hug">
+    <div class="content_action">
+      {% link_for _('Edit settings'), controller='user', action='edit', id=user.name, class_='btn', icon='cog' %}
+    </div>
+    <ul class="nav nav-tabs">
+      {{ h.build_nav_icon('user_dashboard_datasets', _('My Datasets')) }}
+      {{ h.build_nav_icon('user_dashboard_organizations', _('My Organizations')) }}
+      {{ h.build_nav_icon('user_dashboard_groups', _('My Groups')) }}
+    </ul>
+  </header>
+{% endblock %}


### PR DESCRIPTION
Removes the 'News Feed' tab from the dashboard and replaces the default page after logging in with the 'My Datasets' page (instead of the default news feed): https://trello.com/c/ihiAurvS/312-remove-news-feed-tab-from-dashboard

Also removes the 'My Groups' tab from the user dashboard, which is not required as we do not have groups: https://trello.com/c/jZ4Cnns4/362-remove-the-m2y-groups-tab-from-user-dashboard