### PR TITLE
Fix box height

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -53,7 +53,8 @@ a.btn .icon-briefcase {
   margin-left: 145px;
 }
 
-.controls select {
+.controls #field-schema-vocabulary,
+.controls #field-codelist {
   width: 100%;
   height: 120px;
 }


### PR DESCRIPTION
A recently added CSS rule was not specific enough, this targets it at the required areas and removes the knock on effect on other pages.

Before:
![screen shot 2018-06-22 at 09 40 11](https://user-images.githubusercontent.com/31649453/41767604-07d60664-7602-11e8-9052-5949f61e893d.png)

After:
![screen shot 2018-06-22 at 09 40 40](https://user-images.githubusercontent.com/31649453/41767615-0ebc8b10-7602-11e8-9d2c-2ce018a9b0be.png)
