### PR TITLE
Deal with imported datasets that do not have an assigned theme

### DIFF
--- a/ckanext/datagovuk/logic/theme_validator.py
+++ b/ckanext/datagovuk/logic/theme_validator.py
@@ -7,7 +7,7 @@ import re
 
 def valid_theme(key, data, errors, context):
     value = data.get(key)
-    if value in themes():
+    if value in themes() or value == 'None':
         return
     else:
         raise Invalid(_('Primary theme {theme} is not valid'.format(theme=value)))

--- a/import/migrate_datasets.py
+++ b/import/migrate_datasets.py
@@ -69,6 +69,8 @@ def clean_and_write(dataset_json):
         else:
             dataset['theme-primary'] = 'None'
             stats.add('Primary theme mapping not possible', dataset['name'])
+    else:
+        dataset['theme-primary'] = 'None'
 
     # Set 'codelist' to a list of codelist ids
     if 'codelist' in dataset:


### PR DESCRIPTION
Assign a primary theme of 'None' to imported datasets that do not have a theme.

Also allow 'None' as a valid theme in the validator.  This will only ever apply to imported datasets, since the drop-down menu will effectively limit the publisher's choices.