### PR TITLE
Trigger deploys of CKAN to integration when master builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
       }
 
       stage('Deploy to Integration') {
-        govuk.deployIntegration(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
+        govuk.deployIntegration('ckan', BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
       }
     }
   } catch (e) {


### PR DESCRIPTION
The "app name" of CKAN is different for deployment than in
this repository, so we specifically have to trigger a build
for `ckan`.