### PR TITLE
Demote geographic_coverage to extras

### DIFF
--- a/import/migrate_datasets.py
+++ b/import/migrate_datasets.py
@@ -80,7 +80,7 @@ def clean_and_write(dataset_json):
         dataset['schema-vocabulary'] = list_of_ids
         dataset.pop('schema')
     # Shunt custom fields into extras (while we work out what to do with them)
-    for key in ['archival', 'qa', 'theme-secondary']:
+    for key in ['archival', 'qa', 'theme-secondary', 'geographic_coverage']:
         if key not in dataset:
             continue
         # delete an extra in that name if it exists


### PR DESCRIPTION
This ensures we retain the correct data from legacy when importing to new CKAN.

https://trello.com/c/CnrBH5b9/428-make-sync-compatible-with-legacy-geographiccoverage-field