### PR TITLE
Correct the order of validation for theme-primary

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -42,8 +42,8 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     def _modify_package_schema(self, schema):
         schema.update({
-            'theme-primary': [toolkit.get_validator('valid_theme'),
-                              toolkit.get_validator('ignore_missing'),
+            'theme-primary': [toolkit.get_validator('ignore_missing'),
+                              toolkit.get_validator('valid_theme'),
                               toolkit.get_converter('convert_to_extras')],
             'licence-custom': [toolkit.get_validator('ignore_missing'),
                               toolkit.get_converter('convert_to_extras')],


### PR DESCRIPTION
Whilst writing some tests for ckanext-datagovuk, I discovered the `theme-primary` gets validated in the wrong order.  We only want to check if the user has entered a valid theme if there is actually some content to check.