### PR TITLE
Fix the instructions for running tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,10 @@ Running the Tests
 
 To run the tests, do::
 
-    nosetests --nologcapture --with-pylons=test.ini
+    nosetests --nologcapture --with-pylons=/vagrant/src/ckan/test-core.ini
 
 To run the tests and produce a coverage report, first make sure you have
 coverage installed in your virtualenv (``pip install coverage``) then run::
 
-    nosetests --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests
+    nosetests --nologcapture --with-pylons=/vagrant/src/ckan/test-core.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests
 


### PR DESCRIPTION
The Ansible playbook for the dev VM uses the CKAN config file, but the instructions referred to a DGU config.  This has been changed to make it consistent and get the tests working.