### PR TITLE
Allow uploads for organograms only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,10 @@ Running the Tests
 
 To run the tests, do::
 
-    nosetests --nologcapture --with-pylons=test.ini
+    nosetests -v --nologcapture --with-pylons=test.ini --ckan ckanext.datagovuk
 
 To run the tests and produce a coverage report, first make sure you have
 coverage installed in your virtualenv (``pip install coverage``) then run::
 
-    nosetests --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests
+    nosetests -v --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests --ckan ckanext.datagovuk
 

--- a/bin/jenkins-tests.sh
+++ b/bin/jenkins-tests.sh
@@ -2,4 +2,5 @@
 venv/bin/pip install -r venv/src/ckan/dev-requirements.txt
 dropdb ckan_test; createdb ckan_test
 venv/bin/python setup.py develop
-nosetests --nologcapture --with-pylons=test-jenkins.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests
+paster --plugin=ckan db init -c test-jenkins.ini
+nosetests -v --nologcapture --with-pylons=test-jenkins.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests --ckan ckanext.datagovuk

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -4,4 +4,4 @@ echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" |
 sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 sudo service jetty restart
 sleep 10
-nosetests --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests ckanext/datagovuk/tests
+nosetests -v --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests --ckan ckanext.datagovuk

--- a/ckanext/datagovuk/helpers.py
+++ b/ckanext/datagovuk/helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import operator
+from ckan.model import Package
 from ckan.lib.munge import munge_tag
 
 def remove_duplicates_in_a_list(list_):
@@ -260,8 +261,10 @@ def codelist():
     }
     return codelist_dict
 
-def activate_upload(pkg):
-    return 'organogram' in pkg.get('title', '').lower()
+def activate_upload(pkg_name):
+    pkg_dict = Package.by_name(pkg_name).as_dict()
+    pkg_extras = pkg_dict.get('extras')
+    return 'schema-vocabulary' in pkg_extras and pkg_extras['schema-vocabulary'] in ('538b857a-64ba-490e-8440-0e32094a28a7', 'd3c0b23f-6979-45e4-88ed-d2ab59b005d0')
 
 def roles():
     roles_list = ['Admin', 'Editor']

--- a/ckanext/datagovuk/templates/package/snippets/resource_form.html
+++ b/ckanext/datagovuk/templates/package/snippets/resource_form.html
@@ -8,6 +8,7 @@
   {% else %}
     {% set supp = False %}
   {% endif %}
+  {% if not h.activate_upload(pkg_name) %}
   <label class="control-label" for="field-resource-type">{{ _('Resource Type') }}</label>
   <div class="controls">
     <label class="radio">
@@ -19,9 +20,10 @@
        {{ _('Supporting Document') }}
     </label>
   </div>
+  {% endif %}
   {% set is_upload = (data.url_type == 'upload') %}
   {{ form.image_upload(data, errors, field_url='url', field_upload='upload', field_clear='clear_upload',
-      is_upload_enabled=h.uploads_enabled() and h.activate_upload(data), is_url=data.url and not is_upload, is_upload=is_upload,
+      is_upload_enabled=h.uploads_enabled() and h.activate_upload(pkg_name), is_url=data.url and not is_upload, is_upload=is_upload,
       upload_label=_('Data'), url_label=_('URL'), placeholder=' ') }}
 {% endblock basic_fields_url %}
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-nosetests --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests
+nosetests -v --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests --ckan ckanext.datagovuk


### PR DESCRIPTION
This PR enables the upload feature for only organograms (identified by having a schema vocabulary of either `d3c0b23f-6979-45e4-88ed-d2ab59b005d0` for government departments and `538b857a-64ba-490e-8440-0e32094a28a7` for local authorities).

Additionally, it fixes an issue where tests that interact with the database do not work on Jenkins, by ensuring the database is properly initialised before commencing any tests.

Trello card: https://trello.com/c/odHiWSoq/63-implement-upload-organogram-to-s3