### PR TITLE
Install the S3 plugin during build

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -4,6 +4,7 @@ venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckan/2.
 venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.1.0/pip-requirements.txt)
 venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-dcat/master/requirements.txt)
 venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-spatial/master/pip-requirements.txt)
+venv/bin.pip install -U $(curl -s https://raw.githubusercontent.com/alphagov/ckanext-s3-resources/master/requirements.txt)
 venv/bin/pip install -Ue 'git+https://github.com/ckan/ckan.git@ckan-2.7.0#egg=ckan'
 venv/bin/pip install -r venv/src/ckan/requirements.txt
 venv/bin/pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/ckan/ckanext-dcat.git#egg=ckanext-dcat
 git+https://github.com/ckan/ckanext-harvest.git@v1.1.0#egg=ckanext-harvest
 git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial
+git+https://github.com/alphagov/ckanext-s3-resources#egg=ckanext-s3-resources
 gunicorn


### PR DESCRIPTION
Adds in the `ckanext-s3-resources` plugin that replaces the default CKAN upload behaviour to local storage with uploading to S3.  This change enables to installation to be done by Jenkins.

Trello card: https://trello.com/c/odHiWSoq/63-implement-upload-organogram-to-s3