### PR TITLE
Simplify the gunicorn set up for CKAN

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: unicornherder --gunicorn-bin ./venv/bin/gunicorn -p /var/run/ckan/unicornherder.pid -- --pythonpath ${CKAN_HOME} wsgi_app:application --bind 127.0.0.1:${PORT:-3220} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/app.out.log --error-logfile /var/log/ckan/app.err.log
+web: unicornherder --gunicorn-bin ./venv/bin/gunicorn -p /var/run/ckan/unicornherder.pid -- --paste /var/ckan/ckan.ini --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/app.out.log --error-logfile /var/log/ckan/app.err.log
 celery_priority: ./venv/bin/paster --plugin=ckan jobs worker priority --config=${CKAN_HOME}/ckan.ini
 celery_bulk: ./venv/bin/paster --plugin=ckan jobs worker bulk --config=${CKAN_HOME}/ckan.ini
 harvester_gather_consumer: ./venv/bin/paster --plugin=ckanext-harvest harvester gather_consumer --config=${CKAN_HOME}/ckan.ini


### PR DESCRIPTION
CKAN uses Pylons so is already a WSGI app.  There is no need for us to create a WSGI wrapper to run CKAN in.