### PR TITLE
Remove link to Site Analytics page

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -203,7 +203,6 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
                     action='bulk_process')
 
         route_map.connect('harvest_index', '/harvest', action='index')
-        route_map.connect('site_analytics', '/data/site-usage', action='index')
 
         return route_map
 

--- a/ckanext/datagovuk/templates/header.html
+++ b/ckanext/datagovuk/templates/header.html
@@ -13,8 +13,7 @@
   {{ h.build_nav_main(
     ('search', _('Datasets')),
     ('organizations_index', _('Organizations')),
-    ('harvest_index', _('Harvest')),
-    ('site_analytics', _('Site Analytics'))
+    ('harvest_index', _('Harvest'))
   ) }}
   <li><a href="https://data.gov.uk/support">Support</a></li>
 {% endblock %}

--- a/ckanext/datagovuk/tests/test_paths.py
+++ b/ckanext/datagovuk/tests/test_paths.py
@@ -9,10 +9,6 @@ def test_edit_path():
     path = toolkit.url_for('organization_edit', id='cabinet-office')
     assert(path == '/publisher/edit/cabinet-office')
 
-def test_analytics_path():
-    path = toolkit.url_for('site_analytics')
-    assert(path == '/data/site-usage')
-
 def test_harvest_path():
     path = toolkit.url_for('harvest_index')
     assert(path == '/harvest')


### PR DESCRIPTION
Trello card: https://trello.com/c/JJfnLj1g/57-remove-google-analytics-plugin