### PR TITLE
Bring CKAN up to the same version as in the dev VM

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -5,6 +5,6 @@ venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext
 venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-dcat/master/requirements.txt)
 venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-spatial/master/pip-requirements.txt)
 venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/alphagov/ckanext-s3-resources/master/requirements.txt)
-venv/bin/pip install -Ue 'git+https://github.com/ckan/ckan.git@ckan-2.7.0#egg=ckan'
+venv/bin/pip install -Ue 'git+https://github.com/ckan/ckan.git@ckan-2.7.4#egg=ckan'
 venv/bin/pip install -r venv/src/ckan/requirements.txt
 venv/bin/pip install -r requirements.txt


### PR DESCRIPTION
We have been installing CKAN 2.7.0, but have been developing with CKAN 2.7.4.  This installs the correct version.