### PR TITLE
Gracefully exit if a non-existent username/email is entered

### DIFF
--- a/ckanext/datagovuk/controllers/user.py
+++ b/ckanext/datagovuk/controllers/user.py
@@ -69,7 +69,8 @@ class UserController(UserController):
                 user_obj = context['user_obj']
             except NotFound:
                 # Try getting the user by email
-                user_obj = model.User.by_email(id)[0]
+                user_accounts = model.User.by_email(id)
+                user_obj = user_accounts[0] if len(user_accounts) > 0 else None
 
                 if not user_obj:
                     # Try searching the user

--- a/ckanext/datagovuk/lib/authenticator.py
+++ b/ckanext/datagovuk/lib/authenticator.py
@@ -19,10 +19,11 @@ class UsernamePasswordAuthenticator(UsernamePasswordAuthenticator):
         login = identity['login']
         user = User.by_name(login)
         if user is None:
-          user = User.by_email(login)[0]
+          user_accounts = User.by_email(login)
+          user = user_accounts[0] if len(user_accounts) > 0 else None
 
         if user is None:
-            log.debug('Login failed - username %r not found', login)
+            log.debug('Login failed - username or email address %r is not associated with an account', login)
         elif not user.is_active():
             log.debug('Login as %r failed - user isn\'t active', login)
         elif not user.validate_password(identity['password']):


### PR DESCRIPTION
Currently, if a user attempts to log in and their entry matches neither a username or email address, they get served a 500 error.

This deals with that by ensuring that this instance is captured and an error message served to the user.

Trello card: https://trello.com/c/dLWqvdLB/78-fix-500-error-logging-in-when-email-does-not-have-an-account