### PR TITLE
Tidy the dropdown menus on dataset creation form

### DIFF
--- a/ckanext/datagovuk/logic/theme_validator.py
+++ b/ckanext/datagovuk/logic/theme_validator.py
@@ -7,7 +7,7 @@ import re
 
 def valid_theme(key, data, errors, context):
     value = data.get(key)
-    if value in themes() or value == 'None':
+    if value in themes() or value == 'None' or value == '':
         return
     else:
         raise Invalid(_('Primary theme {theme} is not valid'.format(theme=value)))

--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -69,7 +69,6 @@ a.btn .icon-briefcase {
 .controls #field-schema-vocabulary,
 .controls #field-codelist {
   width: 100%;
-  height: 120px;
 }
 
 .add-member-form .control-set label{

--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -14,7 +14,8 @@
 <div class="control-group">
   <label class="control-label" for="theme-primary">{{ _("Theme") }}</label>
   <div class="controls">
-    <select id="field-theme-primary" name="theme-primary" data-module="autocomplete">
+    <select id="field-theme-primary" name="theme-primary">
+      <option value></option>
       {% for theme in h.alphabetise_dict(h.themes()) %}
         <option value="{{ theme[0] }}" {% if data.get('theme-primary', '') == theme[0] %}selected="selected"{% endif %}>{{ theme[1] }}</option>
       {% endfor %}
@@ -29,7 +30,8 @@
 <div class="control-group">
   <label class="control-label" for="schema-vocabulary">{{ _("Schema/Vocabulary") }}</label>
   <div class="controls">
-    <select multiple id="field-schema-vocabulary" name="schema-vocabulary">
+    <select id="field-schema-vocabulary" name="schema-vocabulary">
+      <option value></option>
       {% for schema in h.alphabetise_dict(h.schemas()) %}
         <option value="{{ schema[0] }}" {% if data.get('schema-vocabulary', '') == schema[0] %}selected="selected"{% endif %}>{{ schema[1].decode("utf8") }}</option>
       {% endfor %}
@@ -44,7 +46,8 @@
 <div class="control-group">
   <label class="control-label" for="codelist">{{ _("Code Lists") }}</label>
   <div class="controls">
-    <select multiple id="field-codelist" name="codelist">
+    <select id="field-codelist" name="codelist">
+      <option value></option>
       {% for codelist in h.alphabetise_dict(h.codelist()) %}
         <option value="{{ codelist[0] }}" {% if data.get('codelist', '') == codelist[0] %}selected="selected"{% endif %}>{{ codelist[1] }}</option>
       {% endfor %}


### PR DESCRIPTION
The following fields were poorly formatted and resulted in confusion during user testing:
- Theme
- Schema Vocabulary
- Codelist

This adds a blank default option (rather than selecting the first alphabetically) and only permits one option to be selected.

Before:
<img width="700" alt="screen_shot_2018-10-17_at_14 51 33" src="https://user-images.githubusercontent.com/6329861/47652317-82ffd780-db7d-11e8-8bde-0c7fc4865dbc.png">

After:
<img width="692" alt="screen shot 2018-10-29 at 13 15 51" src="https://user-images.githubusercontent.com/6329861/47652326-8abf7c00-db7d-11e8-90b6-428fb27f0dc6.png">

Trello card: https://trello.com/c/9f0G6D2C/77-make-the-schema-vocabulary-and-code-list-selection-boxes-nicer-to-use