### PR TITLE
Remove the "Clear" button for harvest sources

### DIFF
--- a/ckanext/datagovuk/templates/source/admin_base.html
+++ b/ckanext/datagovuk/templates/source/admin_base.html
@@ -1,0 +1,28 @@
+{% ckan_extends %}
+
+{% block action_links %}
+  {% if harvest_source.status and harvest_source.status.last_job and (harvest_source.status.last_job.status == 'New' or harvest_source.status.last_job.status == 'Running') %}
+    <a class="btn btn-default disabled" rel="tooltip" title="There already is an unrun job for this source"><i class="fa fa-lg fa-refresh icon-refresh icon-large"></i> Reharvest</a>
+  {% else %}
+    {% set locale = h.dump_json({'content': _('This will re-run the harvesting for this source. Any updates at the source will overwrite the local datasets. Sources with a large number of datasets may take a significant amount of time to finish harvesting. Please confirm you would like us to start reharvesting.')}) %}
+
+      <a href="{{ h.url_for('harvest_refresh', id=harvest_source.id) }}" class="btn btn-default" data-module="confirm-action" data-module-i18n="{{ locale }}"
+         title="{{ _('Start a new harvesting job for this harvest source now') }}">
+        <i class="fa fa-refresh icon-refresh"></i>
+        {{ _('Reharvest') }}
+      </a>
+
+  {% endif %}
+  {% if harvest_source.status and harvest_source.status.last_job and (harvest_source.status.last_job.status == 'Running') %}
+
+      <a href="{{ h.url_for('harvest_job_abort', source=harvest_source.name, id=harvest_source.status.last_job.id) }}" class="btn btn-default" title="Stop this Job">
+        <i class="fa fa-ban icon-ban-circle"></i>
+        {{ _('Stop') }}
+      </a>
+
+  {% endif %}
+       <a href="{{ h.url_for('{0}_read'.format(c.dataset_type), id=harvest_source.id) }}" class="btn btn-default">
+        <i class="fa fa-eye eye-open"></i>
+        {{ _('View harvest source') }}
+      </a>
+{% endblock %}

--- a/ckanext/datagovuk/tests/test_harvest_admin.py
+++ b/ckanext/datagovuk/tests/test_harvest_admin.py
@@ -1,0 +1,32 @@
+from routes import url_for
+
+from ckanext.harvest import model as harvest_model
+from ckan.tests import factories
+import ckanext.harvest.tests.factories as harvest_factories
+
+from ckan.tests.helpers import FunctionalTestBase
+from ckanext.datagovuk.tests.db_test import DBTest
+
+
+class TestHarvestAdmin(FunctionalTestBase, DBTest):
+    def setUp(self):
+        super(self.__class__, self).setUp()
+
+        harvest_model.setup()
+
+        self.env = {'REMOTE_USER': factories.Sysadmin()['name'].encode('ascii')}
+        self.source = harvest_factories.HarvestSource()
+        self.app = self._get_test_app()
+
+    def test_clear_button_is_removed(self):
+        response = self._get_harvest_admin_page()
+
+        self.assertIn('View harvest source', response.body)
+        self.assertNotIn('Clear', response.body)
+
+    def _get_harvest_admin_page(self):
+        response = self.app.get(
+            url=url_for('harvest_admin', id=self.source['id']),
+            extra_environ=self.env,
+        )
+        return response

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,9 @@ setup(
         datagovuk_publisher_form=ckanext.datagovuk.forms.publisher:PublisherForm
         inventory_harvester=ckanext.datagovuk.harvesters.inventory_harvester:InventoryHarvester
 
+        [ckan.test_plugins]
+        test_harvester=ckanext.harvest.tests.test_queue:MockHarvester
+
         [paste.paster_command]
         passwords_reset = ckanext.datagovuk.lib.cli:PasswordResetsCommand
 

--- a/test-jenkins.ini
+++ b/test-jenkins.ini
@@ -16,7 +16,7 @@ solr_url = http://127.0.0.1:8983/solr
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.
-ckan.plugins = datagovuk harvest inventory_harvester
+ckan.plugins = datagovuk harvest inventory_harvester test_harvester
 
 # Logging configuration
 [loggers]

--- a/test.ini
+++ b/test.ini
@@ -13,7 +13,7 @@ use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.
-ckan.plugins = datagovuk harvest inventory_harvester
+ckan.plugins = datagovuk harvest inventory_harvester test_harvester
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
This doesn't behave the way users will expect given other changes
to our CKAN, so we're just going to remove it.

This is the minimal amount of template I could copy over from the
harvest plugin, unfortunately there's no more granular `block` hooks to
override.

This means we should keep an eye on changes to this section of the
template when upgrading the harvest plugin.

https://trello.com/c/aAiZQ3sK/90-remove-the-clear-button-from-harvest-source-page