### PR TITLE
Remove truncation of resource names

### DIFF
--- a/ckanext/datagovuk/templates/package/resource_read.html
+++ b/ckanext/datagovuk/templates/package/resource_read.html
@@ -1,4 +1,8 @@
 {% ckan_extends %}
 
+{% block resource_read_title %}
+  <h1 class="page-heading">{{ h.resource_display_name(res) }}</h1>
+{% endblock %}
+
 {% block resource_license %}
 {% endblock %}

--- a/ckanext/datagovuk/templates/package/snippets/resource_item.html
+++ b/ckanext/datagovuk/templates/package/snippets/resource_item.html
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+{% block resource_item_title %}
+  <div style="inline-block">
+    <a class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
+      {{ h.resource_display_name(res) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span>
+      {{ h.popular('views', res.tracking_summary.total, min=10) }}
+    </a>
+  </div>
+{% endblock %}
+
+{% block resource_item_explore %}
+{% endblock %}


### PR DESCRIPTION
Resource names were being truncated at 50 characters on both the list of resources and also the actual resource itself.  This meant that a publisher could not differentiate between resources that have the same first 50 characters.

This PR removes truncation in both places and removes the green 'More' button, which confused users during testing and simply duplicates the behaviour of clicking the resource name.

Before:
<img width="992" alt="screen shot 2018-10-04 at 10 39 24" src="https://user-images.githubusercontent.com/6329861/47787041-8a51ed00-dd05-11e8-9124-d6147e84e455.png">

<img width="733" alt="screen shot 2018-10-31 at 12 09 29" src="https://user-images.githubusercontent.com/6329861/47787158-e4eb4900-dd05-11e8-89a9-1731ada6663b.png">

After:
<img width="781" alt="screen shot 2018-10-31 at 12 04 24" src="https://user-images.githubusercontent.com/6329861/47787026-7dcd9480-dd05-11e8-8d88-bd9a9f999e76.png">

<img width="752" alt="screen shot 2018-10-31 at 12 04 17" src="https://user-images.githubusercontent.com/6329861/47787063-976edc00-dd05-11e8-9e4f-ed9ac0723725.png">

Trello card: https://trello.com/c/PU1T4N10/54-data-file-names-are-truncated