### PR TITLE
Remove inheritance from CKAN for testing

### DIFF
--- a/bin/jenkins-tests.sh
+++ b/bin/jenkins-tests.sh
@@ -4,6 +4,7 @@ venv/bin/pip install -r dev-requirements.txt
 dropdb ckan_test; createdb ckan_test
 venv/bin/python setup.py develop
 paster --plugin=ckan db init -c test-jenkins.ini
+paster --plugin=ckanext-harvest harvester initdb -c test-jenkins.ini
 
 export TEST_CKAN_INI=test-jenkins.ini
 bin/run-tests.sh

--- a/test-jenkins.ini
+++ b/test-jenkins.ini
@@ -1,24 +1,17 @@
-[DEFAULT]
-debug = false
-smtp_server = localhost
-error_email_from = paste@localhost
-
 [server:main]
 use = egg:Paste#http
 host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:venv/src/ckan/test-core.ini
+use = config:test.ini
 
 sqlalchemy.url = postgresql:///ckan_test
 solr_url = http://127.0.0.1:8983/solr
 
-# Insert any custom config settings to be used when running your extension's
-# tests here.
-ckan.plugins = datagovuk harvest inventory_harvester test_harvester
+ckan.datastore.write_url = postgresql:///datastore_test
+ckan.datastore.read_url = postgresql:///datastore_test
 
-# Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy
 

--- a/test.ini
+++ b/test.ini
@@ -9,11 +9,100 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = egg:ckan
+full_stack = true
+cache_dir = /tmp/beaker-test
+debug = false
+testing = true
 
-# Insert any custom config settings to be used when running your extension's
-# tests here.
+# Specify the Postgres database for SQLAlchemy to use
+sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
+
+## Datastore
+ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_test
+ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_test
+
+ckan.datapusher.url = http://datapusher.ckan.org/
+ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+
+## Solr support
+solr_url = http://127.0.0.1:8983/solr
+
+# Redis URL. Use a separate Redis database for testing.
+ckan.redis.url = redis://localhost:6379/1
+
+ckan.auth.user_create_organizations = true
+ckan.auth.user_create_groups = true
+ckan.auth.create_user_via_api = false
+ckan.auth.create_user_via_web = true
+ckan.auth.create_dataset_if_not_in_organization = true
+ckan.auth.anon_create_dataset = false
+ckan.auth.user_delete_groups=true
+ckan.auth.user_delete_organizations=true
+ckan.auth.create_unowned_dataset=true
+
+ckan.cache_validation_enabled = True
+ckan.cache_enabled = False
+ckan.tests.functional.test_cache.expires = 1800
+ckan.tests.functional.test_cache.TestCacheBasics.test_get_cache_expires.expires = 3600
+
+ckan.site_id = test.ckan.net
+ckan.site_title = CKAN
+ckan.site_logo = /images/ckan_logo_fullname_long.png
+ckan.site_description =
+package_form = standard
+licenses_group_url =
+# pyamqplib or queue
+carrot_messaging_library = queue
+ckan.site_url = http://test.ckan.net
+package_new_return_url = http://localhost/dataset/<NAME>?test=new
+package_edit_return_url = http://localhost/dataset/<NAME>?test=edit
+ckan.extra_resource_fields = alt_url
+
+# we need legacy templates for many tests to pass
+ckan.legacy_templates = yes
+
+# Add additional test specific configuration options as necessary.
+auth.blacklist = 83.222.23.234
+
+search_backend = sql
+
+# Change API key HTTP header to something non-standard.
+apikey_header_name = X-Non-Standard-CKAN-API-Key
+
 ckan.plugins = datagovuk harvest inventory_harvester test_harvester
+
+# use <strong> so we can check that html is *not* escaped
+ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">
+
+# use <strong> so we can check that html is *not* escaped
+ckan.template_footer_end = <strong>TEST TEMPLATE_FOOTER_END TEST</strong>
+
+# mailer
+smtp.test_server = localhost:6675
+smtp.mail_from = info@test.ckan.net
+
+ckan.locale_default = en
+ckan.locale_order = en
+ckan.locales_filtered_out =
+
+ckanext.stats.cache_enabled = 0
+
+ckan.datasets_per_page = 20
+
+ckan.activity_streams_email_notifications = True
+
+ckan.activity_list_limit = 15
+
+ckan.tracking_enabled = true
+
+beaker.session.key = ckan
+beaker.session.secret = This_is_a_secret_or_is_it
+
+# repoze.who config
+who.config_file = %(here)s/who.ini
+who.log_level = warning
+who.log_file = %(cache_dir)s/who_log.ini
 
 # Logging configuration
 [loggers]
@@ -37,7 +126,7 @@ level = INFO
 [logger_sqlalchemy]
 handlers =
 qualname = sqlalchemy.engine
-level = WARN
+level = WARNING
 
 [handler_console]
 class = StreamHandler

--- a/who.ini
+++ b/who.ini
@@ -1,0 +1,37 @@
+[plugin:auth_tkt]
+use = ckan.lib.auth_tkt:make_plugin
+# If no secret key is defined here, beaker.session.secret will be used
+#secret = somesecret
+
+[plugin:friendlyform]
+use = repoze.who.plugins.friendlyform:FriendlyFormPlugin
+login_form_url= /user/login
+login_handler_path = /login_generic
+logout_handler_path = /user/logout
+rememberer_name = auth_tkt
+post_login_url = /user/logged_in
+post_logout_url = /user/logged_out
+charset = utf-8
+
+#[plugin:basicauth]
+#use = repoze.who.plugins.basicauth:make_plugin
+#realm = 'CKAN'
+
+[general]
+request_classifier = repoze.who.classifiers:default_request_classifier
+challenge_decider = repoze.who.classifiers:default_challenge_decider
+
+[identifiers]
+plugins =
+    friendlyform;browser
+    auth_tkt
+
+[authenticators]
+plugins =
+    auth_tkt
+    ckan.lib.authenticator:UsernamePasswordAuthenticator
+
+[challengers]
+plugins =
+    friendlyform;browser
+#   basicauth


### PR DESCRIPTION
There were two test configurations: `test.ini` and `test-jenkins.ini`.  These both inherited another configuration from core CKAN, which is located in a different location for each test environment.

Changes to the test configuration had to be made in both files, which resulted in duplication of effort and possibility for things to be missed.

This change removes the inheritance from core CKAN and removes duplication from `test-jenkins.ini`, which now inherits as much as possible from the main DGU test configuration.

Trello card: https://trello.com/c/IAIVU3Vc/92-just-use-one-ini-file-in-local-and-jenkins-testing