### PR TITLE
Install deps in the same file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
     stage('Installing Packages') {
       sh("rm -rf ./venv")
       sh("virtualenv --no-site-packages ./venv")
-      sh("./bin/install-dependencies.sh")
+      sh("./bin/install-dependencies.sh ./venv/bin/pip")
     }
 
     stage('Tests') {

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -1,10 +1,21 @@
 #! /bin/bash
 
-venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckan/2.7/requirement-setuptools.txt)
-venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-harvest/c21c1627992cbcf0043b7b6873ff899f6f66767f/pip-requirements.txt)
-venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-dcat/master/requirements.txt)
-venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-spatial/master/pip-requirements.txt)
-venv/bin/pip install -U $(curl -s https://raw.githubusercontent.com/alphagov/ckanext-s3-resources/master/requirements.txt)
-venv/bin/pip install -Ue 'git+https://github.com/ckan/ckan.git@ckan-2.7.4#egg=ckan'
-venv/bin/pip install -r venv/src/ckan/requirements.txt
-venv/bin/pip install -r requirements.txt
+pip=${1-'/usr/bin/env pip'}
+
+$pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-harvest/c21c1627992cbcf0043b7b6873ff899f6f66767f/pip-requirements.txt)
+$pip install -U 'git+https://github.com/ckan/ckanext-harvest.git@c21c1627992cbcf0043b7b6873ff899f6f66767f#egg=ckanext-harvest'
+
+$pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-dcat/v0.0.8/requirements.txt)
+$pip install -U 'git+https://github.com/ckan/ckanext-dcat.git@v0.0.8#egg=ckanext-dcat'
+
+$pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-spatial/2acf66b110ba534750cab754a50566505ba88d83/pip-requirements.txt)
+$pip install -U 'git+https://github.com/ckan/ckanext-spatial.git@2acf66b110ba534750cab754a50566505ba88d83#egg=ckanext-spatial'
+
+$pip install -U $(curl -s https://raw.githubusercontent.com/alphagov/ckanext-s3-resources/50341b3960a6be3aba5a1558e80dd9a8c7c70c2c/requirements.txt)
+$pip install -U 'git+https://github.com/alphagov/ckanext-s3-resources@50341b3960a6be3aba5a1558e80dd9a8c7c70c2c#egg=ckanext-s3-resources'
+
+$pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckan/ckan-2.7.4/requirement-setuptools.txt)
+$pip install -r https://raw.githubusercontent.com/ckan/ckan/ckan-2.7.4/requirements.txt
+$pip install -Ue 'git+https://github.com/ckan/ckan.git@ckan-2.7.4#egg=ckan'
+
+$pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-git+https://github.com/ckan/ckanext-dcat.git#egg=ckanext-dcat
-git+https://github.com/ckan/ckanext-harvest.git@c21c1627992cbcf0043b7b6873ff899f6f66767f#egg=ckanext-harvest
-git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial
-git+https://github.com/alphagov/ckanext-s3-resources#egg=ckanext-s3-resources
 gunicorn
 pandas==0.23.4
 xlrd==1.1.0


### PR DESCRIPTION
This makes it easier to keep versions of eggs and their requirements in sync.

We shouldn't *need* to do this, but it seems the developers of these eggs haven't properly specified their own dependencies.

https://trello.com/c/pxc8vszb/89-get-ckan-running-in-staging-and-production