### PR TITLE
Correctly include the DGU CSS as a resource

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -28,6 +28,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     def update_config(self, config):
         toolkit.add_template_directory(config, 'templates')
         toolkit.add_public_directory(config, 'public')
+        toolkit.add_resource('public', 'public')
 
     # IAuthFunctions
 

--- a/ckanext/datagovuk/templates/base.html
+++ b/ckanext/datagovuk/templates/base.html
@@ -16,5 +16,5 @@
 
 {% block styles %}
   {{ super() }}
-  <link rel="stylesheet" href="/datagovuk.css" />
+  {% resource 'public/datagovuk.css' %}
 {% endblock %}


### PR DESCRIPTION
It is currently not included in the same way as other resources (using Fanstatic).  This fixes that.