### PR TITLE
Update CKAN homepage layout and content

### DIFF
--- a/ckanext/datagovuk/i18n/en_GB/LC_MESSAGES/ckan.po
+++ b/ckanext/datagovuk/i18n/en_GB/LC_MESSAGES/ckan.po
@@ -3221,17 +3221,14 @@ msgstr ""
 msgid "Welcome to CKAN"
 msgstr "Welcome to Data publisher"
 
-#: ckan/templates/home/snippets/promoted.html:10
-msgid ""
-"This is a nice introductory paragraph about CKAN or the site in general. We "
-"don't have any copy to go here yet but soon we will "
-msgstr ""
-"This is a nice introductory paragraph about Data publisher or the site in general. We "
-"don't have any copy to go here yet but soon we will "
+msgid "Publish and update data for your organisation"
+msgstr "Publish and update data for your organisation"
 
-#: ckan/templates/home/snippets/promoted.html:19
-msgid "This is a featured section"
-msgstr "This is a featured section"
+msgid "You must create an account to use this service."
+msgstr "You must create an account to use this service."
+
+msgid "If you already have an account, sign in to publish a new dataset or update an existing one."
+msgstr "If you already have an account, sign in to publish a new dataset or update an existing one."
 
 #: ckan/templates/home/snippets/search.html:2
 msgid "E.g. environment"

--- a/ckanext/datagovuk/i18n/en_GB/LC_MESSAGES/ckan.po
+++ b/ckanext/datagovuk/i18n/en_GB/LC_MESSAGES/ckan.po
@@ -3230,6 +3230,15 @@ msgstr "You must create an account to use this service."
 msgid "If you already have an account, sign in to publish a new dataset or update an existing one."
 msgstr "If you already have an account, sign in to publish a new dataset or update an existing one."
 
+msgid "Contact the data.gov.uk team"
+msgstr "Contact the data.gov.uk team"
+
+msgid "data.gov.uk is built by Government Digital Service"
+msgstr "data.gov.uk is built by Government Digital Service"
+
+msgid "Contact support"
+msgstr "Contact support"
+
 #: ckan/templates/home/snippets/search.html:2
 msgid "E.g. environment"
 msgstr "E.g. environment"

--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -5,6 +5,7 @@
 body {
   font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
   font-size: 16px;
+  background: #FFF;
 }
 
 .masthead .navigation .nav-pills li a,
@@ -78,3 +79,34 @@ a.btn .icon-briefcase {
 label:after {
   content: "";
 }
+
+.hero {
+  background: #128400;
+}
+
+.home-content {
+  color: #FFF;
+}
+
+h1.home-heading {
+  font-size: 42px;
+}
+
+p.home-text {
+  font-size: 22px;
+  line-height: 1.5;
+}
+
+.home-footer {
+  color: #000;
+}
+
+h1.home-footer-heading {
+  font-size: 28px;
+}
+
+p.home-footer-text {
+  font-size: 16px;
+  line-height: 1.5;
+}
+

--- a/ckanext/datagovuk/templates/home/layout.html
+++ b/ckanext/datagovuk/templates/home/layout.html
@@ -2,9 +2,16 @@
   <div class="container">
     <div class="row row1">
       <div class="span6 col1">
-        {% block promoted %}
-          {% snippet 'home/snippets/promoted.html' %}
-        {% endblock %}
+        <div class="module-content box">
+          <header>
+            <h1 class="page-heading">{{ _("Publish and update data for your organisation") }}</h1>
+            <p>
+              {{ _("You must create an account to use this service.") }}
+            </p>
+            <p>
+              {{ _("If you already have an account, sign in to publish a new dataset or update an existing one.") }}
+            </p>
+        </header>
       </div>
     </div>
   </div>

--- a/ckanext/datagovuk/templates/home/layout.html
+++ b/ckanext/datagovuk/templates/home/layout.html
@@ -1,19 +1,36 @@
 <div role="main" class="hero">
   <div class="container">
     <div class="row row1">
-      <div class="span6 col1">
-        <div class="module-content box">
+      <div class="span10 col1">
+        <div class="module-content home-content">
           <header>
-            <h1 class="page-heading">{{ _("Publish and update data for your organisation") }}</h1>
-            <p>
+            <h1 class="home-heading">{{ _("Publish and update data for your organisation") }}</h1>
+            <p class="home-text">
               {{ _("You must create an account to use this service.") }}
             </p>
-            <p>
+            <p class="home-text">
               {{ _("If you already have an account, sign in to publish a new dataset or update an existing one.") }}
             </p>
-        </header>
+          </header>
+        </div>
       </div>
     </div>
   </div>
 </div>
-
+<div role="footer" class="home-footer">
+  <div class="container">
+    <div class="row row1">
+      <div class="span10 col1">
+        <div class="module-content home-footer">
+          <h1 class="home-footer-heading">{{ _("Contact the data.gov.uk team") }}</h1>
+          <p class="home-footer-text">
+            {{ _("data.gov.uk is built by Government Digital Service") }}
+          </p>
+          <p class="home-footer-text">
+            <a href="https://data.gov.uk/support">{{ _("Contact support") }}</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Removes the default CKAN homepage content and design.  Replaces with content similar to that planned for the new Publish app.

Before:
<img width="1437" alt="screen shot 2018-11-29 at 11 21 33" src="https://user-images.githubusercontent.com/6329861/49278928-0f076680-f47e-11e8-8e12-a7d60bed97ac.png">

After:
<img width="1440" alt="screen shot 2018-11-29 at 15 15 14" src="https://user-images.githubusercontent.com/6329861/49278938-162e7480-f47e-11e8-82d9-fd7d2aee2c62.png">

Trello card: https://trello.com/c/ZhPoqwZp/123-update-ckan-homepage