### PR TITLE
Update SQL migration script

### DIFF
--- a/migrations/001_bytemark_to_govuk.sql
+++ b/migrations/001_bytemark_to_govuk.sql
@@ -33,7 +33,7 @@ UPDATE resource SET state = 'deleted' WHERE description = 'Organogram viewer';
 -- Users
 
 -- Remove non-publishing users
-DELETE FROM "user" CASCADE WHERE id NOT IN (SELECT DISTINCT user_id FROM user_object_role WHERE role = 'admin' OR role = 'editor');
+DELETE FROM "user" CASCADE WHERE id NOT IN (SELECT DISTINCT user_id FROM user_object_role WHERE role = 'admin' OR role = 'editor') AND sysadmin <> 't';
 
 -- Demote all sysadmins
 UPDATE "user" SET sysadmin = 'f';

--- a/migrations/001_bytemark_to_govuk.sql
+++ b/migrations/001_bytemark_to_govuk.sql
@@ -39,7 +39,7 @@ DELETE FROM "user" CASCADE WHERE id NOT IN (SELECT DISTINCT user_id FROM user_ob
 UPDATE "user" SET sysadmin = 'f';
 
 -- Remove the user's Drupal ID from their username and set their actual username
-UPDATE "user" SET name = fullname;
+UPDATE "user" SET name = fullname WHERE fullname IS NOT NULL;
 
 -- Harvest sources
 


### PR DESCRIPTION
There were two issues with the SQL migration process:
- We were deleting sysadmin users, when they should have just been demoted
- There is a not null constraint on the `name` column so we should only update where there is a non-null value

Trello card: https://trello.com/c/IOJpy2to/126-document-process-for-getting-postgres-database-dump-onto-aws