### PR TITLE
Fix typo that stops Manage Harvest button working

### DIFF
--- a/ckanext/datagovuk/templates/source/read_base.html
+++ b/ckanext/datagovuk/templates/source/read_base.html
@@ -1,5 +1,5 @@
 {% ckan_extends %}
 
 {% block admin_link %}
-  {{ h.nav_link(_('Manage'), named_route='{0}_admin'.format(c.dataset_type), id=c.harvest_source.name, class_='btn btn-primary', icon='wrench')}}
+  {{ h.nav_link(_('Manage'), named_route='{0}_admin'.format(c.dataset_type), id=harvest_source.name, class_='btn btn-primary', icon='wrench')}}
 {% endblock %}


### PR DESCRIPTION
This creates a link to `/harvest/admin/` rather than `/harvest/admin/source-name` at the moment.