### PR TITLE
Soft-delete the organogram viewer resources during migration

### DIFF
--- a/migrations/001_bytemark_to_govuk.sql
+++ b/migrations/001_bytemark_to_govuk.sql
@@ -26,6 +26,10 @@ UPDATE package_extra SET key = 'schema-vocabulary' WHERE key = 'schema';
 DELETE FROM package_tag CASCADE;
 DELETE FROM tag;
 
+-- Remove the organogram viewer resources (links)
+
+UPDATE resource SET state = 'deleted' WHERE description = 'Organogram viewer';
+
 -- Users
 
 -- Remove non-publishing users


### PR DESCRIPTION
The organogram viewer has been implemented in Find, so it is no longer necessary to have a link to CKAN as one of the resources.

Trello card: https://trello.com/c/VC7gQm5p/128-remove-links-to-organogram-viewer