### PR TITLE
Add Google Analytics tracking code

### DIFF
--- a/ckanext/datagovuk/helpers.py
+++ b/ckanext/datagovuk/helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import operator
+from ckan.common import config
 from ckan.model import Package
 from ckan.lib.munge import munge_tag
 
@@ -269,3 +270,6 @@ def activate_upload(pkg_name):
 def roles():
     roles_list = ['Admin', 'Editor']
     return roles_list
+
+def google_analytics_tracking_id():
+    return config.get('ckan.google_analytics_tracking_id')

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -221,6 +221,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             'codelist': h.codelist,
             'alphabetise_dict': h.alphabetise_dict,
             'roles': h.roles,
+            'google_analytics_tracking_id': h.google_analytics_tracking_id,
         }
 
     import ckanext.datagovuk.ckan_patches  # import does the monkey patching

--- a/ckanext/datagovuk/templates/base.html
+++ b/ckanext/datagovuk/templates/base.html
@@ -14,6 +14,24 @@
   {%- endif %}
 {% endblock %}
 
+{% block head_extras %}
+  {% set ga_id = h.google_analytics_tracking_id() %}
+  {% if ga_id %}
+    <!-- Google Analytics -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      
+      ga('create','{{ ga_id }}', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics -->
+  {% endif %}
+  {{ super() }}
+{% endblock %}
+
 {% block styles %}
   {{ super() }}
   {% resource 'public/datagovuk.css' %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 gunicorn
 lxml>=2.3
+numpy==1.15.4
 pandas==0.23.4
 Shapely>=1.2.13
 xlrd==1.1.0


### PR DESCRIPTION
The tracking ID is configured separately in `ckan.ini` (https://github.com/alphagov/govuk-puppet/pull/8484).

Trello card: https://trello.com/c/zBKmvCwm/137-add-google-analytics-to-ckan