### PR TITLE
Remove publisher image upload

### DIFF
--- a/ckanext/datagovuk/templates/organization/snippets/organization_form.html
+++ b/ckanext/datagovuk/templates/organization/snippets/organization_form.html
@@ -24,9 +24,4 @@
 
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my organization...'), value=data.description, error=errors.description) }}
 
-    {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
-    {% set is_url = data.image_url and data.image_url.startswith('http') %}
-
-    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
-
   {% endblock %}


### PR DESCRIPTION
This is not shown anywhere but CKAN, so it is pointless for a publisher to upload an image.