### PR TITLE
Add a 'category' extra to the publisher schema

### DIFF
--- a/ckanext/datagovuk/forms/publisher.py
+++ b/ckanext/datagovuk/forms/publisher.py
@@ -17,8 +17,11 @@ class PublisherForm(plugins.SingletonPlugin, toolkit.DefaultOrganizationForm):
     def form_to_db_schema(self):
         from ckan.logic.schema import group_form_schema
         schema = group_form_schema()
-        for contact_key in ['contact-name', 'contact-email', 'contact-phone', 'foi-name', 'foi-email', 'foi-web', 'foi-phone']:
-            schema.update({contact_key: [toolkit.get_validator('ignore_missing'),
+        for mandatory_extra in ['category']:
+            schema.update({mandatory_extra: [toolkit.get_converter('convert_to_extras'),
+                                         unicode]})
+        for optional_extra in ['contact-name', 'contact-email', 'contact-phone', 'foi-name', 'foi-email', 'foi-web', 'foi-phone']:
+            schema.update({optional_extra: [toolkit.get_validator('ignore_missing'),
                                          toolkit.get_converter('convert_to_extras'),
                                          unicode]})
         return schema
@@ -26,8 +29,11 @@ class PublisherForm(plugins.SingletonPlugin, toolkit.DefaultOrganizationForm):
     def db_to_form_schema(self, package_type=None):
         from ckan.logic.schema import default_group_schema
         schema = default_group_schema()
-        for contact_key in ['contact-name', 'contact-email', 'contact-phone', 'foi-name', 'foi-email', 'foi-web', 'foi-phone']:
-            schema.update({contact_key: [toolkit.get_converter('convert_from_extras'),
+        for mandatory_extra in ['category']:
+            schema.update({mandatory_extra: [toolkit.get_converter('convert_from_extras'),
+                                         unicode]})
+        for optional_extra in ['contact-name', 'contact-email', 'contact-phone', 'foi-name', 'foi-email', 'foi-web', 'foi-phone']:
+            schema.update({optional_extra: [toolkit.get_converter('convert_from_extras'),
                                          toolkit.get_validator('ignore_missing'),
                                          unicode]})
         schema['num_followers'] = []

--- a/ckanext/datagovuk/helpers.py
+++ b/ckanext/datagovuk/helpers.py
@@ -262,6 +262,29 @@ def codelist():
     }
     return codelist_dict
 
+def publisher_category():
+    categories = {
+        "": "",
+        "ministerial-department": "Ministerial department",
+        "non-ministerial-department": "Non-ministerial department",
+        "devolved": "Devolved administration",
+        "executive-ndpb": "Executive non-departmental public body",
+        "advisory-ndpb": "Advisory non-departmental public body",
+        "tribunal-ndpb": "Tribunal non-departmental public body",
+        "executive-agency": "Executive agency",
+        "executive-office": "Executive office",
+        "local-council": "Local authority",
+        "nhs": "NHS body",
+        "gov-corporation": "Public corporation",
+        "charity-ngo": "Charity or Non-Governmental Organisation",
+        "private": "Private Sector",
+        "grouping": "A notional grouping of organisations",
+        "sub-organisation": "Sub-organisation",
+        "other": "Other",
+    }
+    return [{'text': value[1], 'value': value[0]}
+            for value in alphabetise_dict(categories)]
+
 def activate_upload(pkg_name):
     pkg_dict = Package.by_name(pkg_name).as_dict()
     pkg_extras = pkg_dict.get('extras')

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -222,6 +222,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             'alphabetise_dict': h.alphabetise_dict,
             'roles': h.roles,
             'google_analytics_tracking_id': h.google_analytics_tracking_id,
+            'publisher_category': h.publisher_category,
         }
 
     import ckanext.datagovuk.ckan_patches  # import does the monkey patching

--- a/ckanext/datagovuk/templates/organization/snippets/organization_form.html
+++ b/ckanext/datagovuk/templates/organization/snippets/organization_form.html
@@ -24,6 +24,8 @@
 
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my organization...'), value=data.description, error=errors.description) }}
 
+    {{ form.select('category', label=_('Category'), options=h.publisher_category(), selected=data.get('category', ''), error=errors.category, attrs=attrs) }}
+
     {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
     {% set is_url = data.image_url and data.image_url.startswith('http') %}
 


### PR DESCRIPTION
Adds a new extra to the publisher schema named 'category'.  Find uses this field to boost datasets from certain categories of publisher in the search results.

Trello card: https://trello.com/c/ltVoVvQu/139-add-a-category-extra-to-the-publisher-schema