### PR TITLE
Fix harvest source validation issues

### DIFF
--- a/migrations/001_bytemark_to_govuk.sql
+++ b/migrations/001_bytemark_to_govuk.sql
@@ -49,3 +49,6 @@ UPDATE harvest_source SET type = 'csw' WHERE type = 'gemini-csw';
 UPDATE harvest_source SET type = 'waf' WHERE type = 'gemini-waf';
 UPDATE harvest_source SET type = 'dcat_json' WHERE type = 'data_json';
 
+-- Change the DKAN harvester to use the data.json format
+UPDATE harvest_source SET url = CONCAT(url, '/data.json'), type = 'dcat_json' WHERE type = 'dkan';
+

--- a/migrations/001_bytemark_to_govuk.sql
+++ b/migrations/001_bytemark_to_govuk.sql
@@ -52,3 +52,8 @@ UPDATE harvest_source SET type = 'dcat_json' WHERE type = 'data_json';
 -- Change the DKAN harvester to use the data.json format
 UPDATE harvest_source SET url = CONCAT(url, '/data.json'), type = 'dcat_json' WHERE type = 'dkan';
 
+-- Remove a duplicated harvest source to fix a validation error
+DELETE FROM harvest_object_extra WHERE harvest_object_id IN (SELECT id FROM harvest_object WHERE harvest_source_id = '2c798023-abac-4785-ad19-67bd5c1aed63');
+DELETE FROM harvest_object WHERE harvest_source_id = '2c798023-abac-4785-ad19-67bd5c1aed63';
+DELETE FROM harvest_job WHERE source_id = '2c798023-abac-4785-ad19-67bd5c1aed63';
+DELETE FROM harvest_source WHERE id = '2c798023-abac-4785-ad19-67bd5c1aed63';


### PR DESCRIPTION
The updated harvest plugin appears to validate the data each time `setup` is run.  Fixing these issues as part of the upgrade database migration will remove this error from being logged.

There are two changes being made:
1. DKAN harvesters are not being supported in new CKAN.  There is only one publisher using this format, so their source is updated to `data.json` so they can continue to harvest.
2. One local authority's harvest source has been entered twice with a different slug but the same source URL.  There is additional URL validation on the harvest sources in newer versions of the harvest plugin which prevents duplication of URLs across harvest sources.

Trello card: https://trello.com/c/GLb5wFtg/140-fix-harvest-source-validation-errors