### PR TITLE
Make category an optional extra when showing orgs

### DIFF
--- a/ckanext/datagovuk/forms/publisher.py
+++ b/ckanext/datagovuk/forms/publisher.py
@@ -29,10 +29,7 @@ class PublisherForm(plugins.SingletonPlugin, toolkit.DefaultOrganizationForm):
     def db_to_form_schema(self, package_type=None):
         from ckan.logic.schema import default_group_schema
         schema = default_group_schema()
-        for mandatory_extra in ['category']:
-            schema.update({mandatory_extra: [toolkit.get_converter('convert_from_extras'),
-                                         unicode]})
-        for optional_extra in ['contact-name', 'contact-email', 'contact-phone', 'foi-name', 'foi-email', 'foi-web', 'foi-phone']:
+        for optional_extra in ['category', 'contact-name', 'contact-email', 'contact-phone', 'foi-name', 'foi-email', 'foi-web', 'foi-phone']:
             schema.update({optional_extra: [toolkit.get_converter('convert_from_extras'),
                                          toolkit.get_validator('ignore_missing'),
                                          unicode]})


### PR DESCRIPTION
When this is mandatory in the DB to form schema it causes a 500 when
dumping the object to JSON if the extra is missing.

Because we have some categories missing in the DB, this change
allows us to render the orgs with the missing category but
requires a category to be provided if saving the org.