### PR TITLE
Set a gunicorn request timeout from puppet

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: unicornherder --gunicorn-bin ./venv/bin/gunicorn -p /var/run/ckan/unicornherder.pid -- --paste ${CKAN_INI} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/app.out.log --error-logfile /var/log/ckan/app.err.log
+web: unicornherder --gunicorn-bin ./venv/bin/gunicorn -p /var/run/ckan/unicornherder.pid -- --paste ${CKAN_INI} --timeout ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/app.out.log --error-logfile /var/log/ckan/app.err.log
 celery_priority: ./venv/bin/paster --plugin=ckan jobs worker priority --config=${CKAN_INI}
 celery_bulk: ./venv/bin/paster --plugin=ckan jobs worker bulk --config=${CKAN_INI}
 harvester_gather_consumer: ./venv/bin/paster --plugin=ckanext-harvest harvester gather_consumer --config=${CKAN_INI}


### PR DESCRIPTION
This allows us to ensure that gunicorn has the same timeout
as nginx.

https://trello.com/c/2rnVLIgT/726-fix-timeout-on-organogram-publishing-recommended-%F0%9F%8D%90-for-dgu-learning

Relies on https://github.com/alphagov/govuk-puppet/pull/8614