### PR TITLE
Disallow indexing by search engine bots

### DIFF
--- a/ckanext/datagovuk/templates/robots.txt
+++ b/ckanext/datagovuk/templates/robots.txt
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block all_user_agents -%}
+Disallow: /
+{%- endblock %}


### PR DESCRIPTION
The way we use CKAN is purely as an administration interface to manage the datasets which are rendered on data.gov.uk using a separate 'Find' application.

Therefore we don't want any robots to be indexing any of the pages in CKAN as they will only be accessible to people who have logged in.

Also we hope this will reduce the 5xx rate on CKAN as bots are frequently requesting a page which is raising a 5xx error and we'd rather stop them accessing this page rather than fixing the issue in CKAN itself.

This is based off [the official template from CKAN](https://github.com/ckan/ckan/blob/master/ckan/templates/robots.txt) but with modifications. As I understand it, templates in plugins will overwrite built in templates.

[Trello Card](https://trello.com/c/PonNGWyO/797-stop-search-engines-from-indexing-ckan)