### PR TITLE
Remove redundant 'celery' workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,3 @@
 web: unicornherder --gunicorn-bin ./venv/bin/gunicorn -p /var/run/ckan/unicornherder.pid -- --paste ${CKAN_INI} --timeout ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/app.out.log --error-logfile /var/log/ckan/app.err.log
-celery_priority: ./venv/bin/paster --plugin=ckan jobs worker priority --config=${CKAN_INI}
-celery_bulk: ./venv/bin/paster --plugin=ckan jobs worker bulk --config=${CKAN_INI}
 harvester_gather_consumer: ./venv/bin/paster --plugin=ckanext-harvest harvester gather_consumer --config=${CKAN_INI}
 harvester_fetch_consumer: ./venv/bin/paster --plugin=ckanext-harvest harvester fetch_consumer --config=${CKAN_INI}


### PR DESCRIPTION
Previously CKAN used to use celery to process background jobs, but since
the migration we were actually using CKAN's new in-built workers, so we
should at least rename them in the Procfile. However, it turns out these
workers haven't been running in prod for 120 days(!), which indicates
they're not necessary and listing the queues shows they're empty.

https://docs.ckan.org/en/2.8/maintaining/background-tasks.html#migrating-from-ckan-s-previous-background-job-system