### PR TITLE
Fix error when uploading XLS that has no schema vocabulary

### DIFF
--- a/ckanext/datagovuk/action/create.py
+++ b/ckanext/datagovuk/action/create.py
@@ -57,7 +57,7 @@ def resource_create(context, data_dict):
             'd3c0b23f-6979-45e4-88ed-d2ab59b005d0', # Departmental
             }
 
-        if pkg_dict['schema-vocabulary'] in organogram_ids:
+        if pkg_dict.get('schema-vocabulary') in organogram_ids:
             log.debug("Organogram detected")
 
             file_handle = data_dict['upload'].file


### PR DESCRIPTION
When a user uploads a file which appears to be an Excel file, we check the schema vocabulary to see if the file should be processed as an organogram.

This fixes an issue where a 500 error is produced when users upload XLS files without selecting a schema-vocabulary.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3666591