### PR TITLE
Fix incorrect organograms schema/vocabs values

### DIFF
--- a/migrations/002_fix_organograms.sql
+++ b/migrations/002_fix_organograms.sql
@@ -1,0 +1,7 @@
+UPDATE package_extra
+SET value = 'd3c0b23f-6979-45e4-88ed-d2ab59b005d0'
+WHERE value = '["d3c0b23f-6979-45e4-88ed-d2ab59b005d0"]';
+
+UPDATE package_extra
+SET value = '538b857a-64ba-490e-8440-0e32094a28a7'
+WHERE value = '["538b857a-64ba-490e-8440-0e32094a28a7"]';


### PR DESCRIPTION
These come from pre-migration and seem to be in a format that CKAN doesn't understand, so we can remove the `["` and `"]` parts to fix them.

```
ckan_production=> SELECT COUNT(*) FROM package_extra WHERE value = '["538b857a-64ba-490e-8440-0e32094a28a7"]';
 count
-------
    18
(1 row)

ckan_production=> SELECT COUNT(*) FROM package_extra WHERE value = '["d3c0b23f-6979-45e4-88ed-d2ab59b005d0"]';
 count
-------
   250
(1 row)
```

[Trello Card](https://trello.com/c/SpUg2rd1/971-fix-tagging-for-dgu-organograms)