### PR TITLE
Redirect /home requests to /

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -181,6 +181,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             m.connect('/user/edit/{id:.*}', action='edit')
             m.connect('/user/reset', action='request_reset')
         route_map.connect('healthcheck', '/healthcheck', controller=healthcheck_controller, action='healthcheck')
+        route_map.redirect('/home', '/')
         return route_map
 
     def after_map(self, route_map):

--- a/ckanext/datagovuk/tests/test_paths.py
+++ b/ckanext/datagovuk/tests/test_paths.py
@@ -1,4 +1,5 @@
 import ckan.plugins.toolkit as toolkit
+import ckan.tests.helpers as helpers
 import ckanext.datagovuk.plugin as plugin
 import unittest
 
@@ -19,3 +20,11 @@ class TestPaths(unittest.TestCase):
     def test_healthcheck_path(self):
         path = toolkit.url_for('healthcheck')
         self.assertEqual(path, '/healthcheck')
+
+    def test_home_path_redirects_to_index(self):
+        app = helpers._get_test_app()
+
+        resp = app.get('/home')
+
+        assert resp.status_int == 302
+        assert resp.location == 'http://localhost/'


### PR DESCRIPTION
## What

Without this redirection the ckan stack respond with a 500 error when a user attempts to go to `/home`.