### PR TITLE
Update sha commit for ckan_s3_resources

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -12,7 +12,7 @@ ckan_spatial_fork='alphagov'
 ckan_spatial_sha='7bdc8c5ff63c91cd7996cd461505bcba9c39a34d'
 
 ckan_s3_resources_fork='alphagov'
-ckan_s3_resources_sha='50341b3960a6be3aba5a1558e80dd9a8c7c70c2c'
+ckan_s3_resources_sha='8014055db7830e4cdd49a7184ef3a1d56613a3a3'
 
 ckan_fork='ckan'
 ckan_sha='ckan-2.7.4'


### PR DESCRIPTION
This includes the latest changes made in https://github.com/alphagov/ckanext-s3-resources
Commit: https://github.com/alphagov/ckanext-s3-resources/commit/8014055db7830e4cdd49a7184ef3a1d56613a3a3

Trello card: https://trello.com/c/5KrmZ1tb/1025-fix-bug-to-show-visualisation-on-junior-post-organograms