### PR TITLE
Add error reporting to Sentry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,11 @@ ckanext-datagovuk
    What does it do? What features does it have?
    Consider including some screenshots or embedding a video!
 
+--------
+Features
+--------
 
-
+- Configures Sentry automatically using a `SENTRY_DSN` environment variable.
 
 ------------
 Installation
@@ -69,4 +72,3 @@ To run the tests and produce a coverage report, first make sure you have
 coverage installed in your virtualenv (``pip install coverage``) then run::
 
     nosetests -v --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.datagovuk --cover-inclusive --cover-erase --cover-tests --ckan ckanext.datagovuk
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ numpy==1.15.4
 pandas==0.23.4
 Shapely>=1.2.13
 xlrd==1.1.0
+sentry-sdk==0.9.0
+blinker==1.4


### PR DESCRIPTION
Rather than using a custom CKAN plugin I've decided that the simplest way to enable Sentry error reporting is to implement it ourselves in this plugin.

All the CKAN Sentry plugins I looked at were a few years out of date and didn't support the new [Sentry SDK](https://github.com/getsentry/sentry-python).

Although this means that we now have to maintain this code, it's fairly simple and most of the work is done by the Python module itself.

Depends on https://github.com/alphagov/govuk-puppet/pull/9311.

[Trello Card](https://trello.com/c/Xv7JmC8g/1084-add-sentry-to-ckan-stack)