### PR TITLE
Update spatial sha to install spatial harvest fix

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,7 @@ ckan_dcat_fork='alphagov'
 ckan_dcat_sha='6253f296c6d1200465a3223710d076cd24e37834'
 
 ckan_spatial_fork='alphagov'
-ckan_spatial_sha='7bdc8c5ff63c91cd7996cd461505bcba9c39a34d'
+ckan_spatial_sha='6cfd3037de27032f07d6ab74a3e1a63ce970385d'
 
 ckan_s3_resources_fork='alphagov'
 ckan_s3_resources_sha='81eb36fb51da5e216e9405a7ad64c4096881ca85'


### PR DESCRIPTION
# What

This update will deploy a fix for spatial harvesters which will allow users to import datasets that share the same name across ckan, it was being limited to 100, but this limit has now been lifted.

# Reference 

https://trello.com/c/7prmDou5/1082-that-url-is-already-in-use-error-message-when-reharvesting