### PR TITLE
Add pycsw setup as part of datagovuk ckan build

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -17,6 +17,8 @@ ckan_s3_resources_sha='81eb36fb51da5e216e9405a7ad64c4096881ca85'
 ckan_fork='ckan'
 ckan_sha='ckan-2.7.4'
 
+pycsw_tag='1.8.3'
+
 $pip install -U pip
 
 $pip install -U $(curl -s https://raw.githubusercontent.com/$ckan_harvest_fork/ckanext-harvest/$ckan_harvest_sha/pip-requirements.txt)
@@ -36,3 +38,9 @@ $pip install -r https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requ
 $pip install -Ue "git+https://github.com/$ckan_fork/ckan.git@$ckan_sha#egg=ckan"
 
 $pip install -r requirements.txt
+
+$pip install -U $(curl -s https://raw.githubusercontent.com/geopython/pycsw.git/$pycsw_tag/requirements.txt)
+$pip install -Ue "git+https://github.com/geopython/pycsw.git@$pycsw_tag#egg=pycsw"
+
+pycsw_src="$(python -m site | grep pycsw | sed "s:[ |,|']::g")"
+(cd $pycsw_src && /usr/bin/env python setup.py build && $pip install -e .)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
+blinker==1.4
 gunicorn
 lxml>=2.3
 numpy==1.16.4
 pandas==0.24.2
 Shapely>=1.2.13
-xlrd==1.2.0
 sentry-sdk==0.10.2
-blinker==1.4
+xlrd==1.2.0


### PR DESCRIPTION
## What

It was decided that we add pycsw here to support the `csw` endpoint as it makes the pulling in of ckan dependencies consistent.

We might have been able to add it as part of spatial but as we are planning on merging our fork back and not all spatial users need the `csw` endpoint served it is better to keep it out.

The `pycsw` version is quite old at `1.8.3`, this is the current working one. Later versions were attempted but there are some odd behaviours which will take some time to investigate. For now it is good enough.

This needs to be merged in before the update to `govuk-puppet` for `csw` can be run.

## Reference

https://trello.com/c/RudwUlvN/1157-update-govuk-puppet-to-deploy-ckan-with-pycsw