### PR TITLE
Fix Jenkins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,9 @@ setup(
         datagovuk_publisher_form=ckanext.datagovuk.forms.publisher:PublisherForm
         inventory_harvester=ckanext.datagovuk.harvesters.inventory_harvester:InventoryHarvester
 
+        [nose.plugins]
+        pylons = pylons.test:PylonsPlugin
+
         [ckan.test_plugins]
         test_harvester=ckanext.harvest.tests.test_queue:MockHarvester
 


### PR DESCRIPTION
- Fix 'error: no such option: --with-pylons'
  (From Pylons 1.0.1, the nose plugin is not registered by Pylons itself
any more.)