### PR TITLE
Add PyCSW to the Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,5 @@
 web: unicornherder --gunicorn-bin ./venv/bin/gunicorn -p /var/run/ckan/unicornherder.pid -- --paste ${CKAN_INI} --timeout ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/app.out.log --error-logfile /var/log/ckan/app.err.log
+pycsw_web: unicornherder --gunicorn-bin ./venv/bin/gunicorn -p /var/run/ckan/pycsw_unicornherder.pid -- ckanext.datagovuk.pycsw_wsgi --bind localhost:${PYCSW_PORT} --timeout ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/pycsw.out.log --error-logfile /var/log/ckan/pycsw.err.log
+
 harvester_gather_consumer: ./venv/bin/paster --plugin=ckanext-harvest harvester gather_consumer --config=${CKAN_INI}
 harvester_fetch_consumer: ./venv/bin/paster --plugin=ckanext-harvest harvester fetch_consumer --config=${CKAN_INI}

--- a/ckanext/datagovuk/pycsw_wsgi.py
+++ b/ckanext/datagovuk/pycsw_wsgi.py
@@ -1,0 +1,88 @@
+# -*- coding: iso-8859-15 -*-
+# =================================================================
+#
+# Authors: Adam Hinz <hinz.adam@gmail.com>
+#
+# Copyright (c) 2012 Adam Hinz
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from StringIO import StringIO
+import os
+import sys
+
+from pycsw import server
+
+
+def application(env, start_response):
+    """WSGI wrapper"""
+    config = os.environ['PYCSW_CONFIG']
+
+    if env['QUERY_STRING'].lower().find('config') != -1:
+        for kvp in env['QUERY_STRING'].split('&'):
+            if kvp.lower().find('config') != -1:
+                config = kvp.split('=')[1]
+
+    if 'HTTP_HOST' in env and ':' in env['HTTP_HOST']:
+        env['HTTP_HOST'] = env['HTTP_HOST'].split(':')[0]
+
+    csw = server.Csw(config, env)
+
+    gzip = False
+    if ('HTTP_ACCEPT_ENCODING' in env and
+            env['HTTP_ACCEPT_ENCODING'].find('gzip') != -1):
+        # set for gzip compressed response
+        gzip = True
+
+    # set compression level
+    if csw.config.has_option('server', 'gzip_compresslevel'):
+        gzip_compresslevel = \
+            int(csw.config.get('server', 'gzip_compresslevel'))
+    else:
+        gzip_compresslevel = 0
+
+    contents = csw.dispatch_wsgi()
+
+    headers = {}
+
+    if gzip and gzip_compresslevel > 0:
+        import gzip
+
+        buf = StringIO()
+        gzipfile = gzip.GzipFile(mode='wb', fileobj=buf,
+                                 compresslevel=gzip_compresslevel)
+        gzipfile.write(contents)
+        gzipfile.close()
+
+        contents = buf.getvalue()
+
+        headers['Content-Encoding'] = 'gzip'
+
+    headers['Content-Length'] = str(len(contents))
+    headers['Content-Type'] = csw.contenttype
+
+    status = '200 OK'
+    start_response(status, headers.items())
+
+    return [contents]


### PR DESCRIPTION
To run the PyCSW server, we need to have it configured in the Procfile so that we can generate an Upstart service for it.

This runs the `pycsw.wsgi` file (provided by the `pycsw` module) using gunicorn.

[Trello Card](https://trello.com/c/RudwUlvN/1157-update-govuk-puppet-to-deploy-ckan-with-pycsw)