### PR TITLE
Remove PII from package search & show

### DIFF
--- a/ckanext/datagovuk/action/get.py
+++ b/ckanext/datagovuk/action/get.py
@@ -13,22 +13,14 @@ import ckan.lib.dictization.model_dictize as model_dictize
 
 from ckan.model import User
 
+from ckanext.datagovuk.pii_helpers import remove_pii, remove_pii_from_list
+
 log = __import__('logging').getLogger(__name__)
 
 
 # defined as they are in ckan/action/get.py to save further hacks to the
 # function copied from there
 _check_access = check_access
-
-PII_LIST = [
-    'author',
-    'author_email',
-    'contact-name',
-    'contact-phone',
-    'contact-email',
-    'maintainer',
-    'maintainer_email'
-]
 
 
 def user_auth(context, data_dict):
@@ -81,6 +73,5 @@ def dgu_package_search(context, data_dict):
 
 
 @side_effect_free
-
 def dgu_package_show(context, data_dict):
     return remove_pii(package_show(context, data_dict))

--- a/ckanext/datagovuk/action/get.py
+++ b/ckanext/datagovuk/action/get.py
@@ -1,8 +1,10 @@
 import ckan.logic.schema
+from ckan.logic.action.get import package_search, package_show
 from ckan.plugins.toolkit import (
     abort,
     check_access,
     navl_validate,
+    side_effect_free,
     ValidationError,
     get_action,
 )
@@ -11,14 +13,22 @@ import ckan.lib.dictization.model_dictize as model_dictize
 
 from ckan.model import User
 
-
 log = __import__('logging').getLogger(__name__)
 
 
-# defined as they are in ckan/action/create.py to save further hacks to the
+# defined as they are in ckan/action/get.py to save further hacks to the
 # function copied from there
 _check_access = check_access
-_validate = navl_validate
+
+PII_LIST = [
+    'author',
+    'author_email',
+    'contact-name',
+    'contact-phone',
+    'contact-email',
+    'maintainer',
+    'maintainer_email'
+]
 
 
 def user_auth(context, data_dict):
@@ -63,3 +73,14 @@ def user_auth(context, data_dict):
     # DGU Hack: added encoding so we don't barf on unicode user names
     log.debug('Authenticated user {name}'.format(name=user.name.encode('utf8')))
     return user_dict
+
+
+@side_effect_free
+def dgu_package_search(context, data_dict):
+    return remove_pii_from_list(package_search(context, data_dict))
+
+
+@side_effect_free
+
+def dgu_package_show(context, data_dict):
+    return remove_pii(package_show(context, data_dict))

--- a/ckanext/datagovuk/pii_helpers.py
+++ b/ckanext/datagovuk/pii_helpers.py
@@ -1,0 +1,22 @@
+PII_LIST = [
+    'author',
+    'author_email',
+    'contact-name',
+    'contact-phone',
+    'contact-email',
+    'maintainer',
+    'maintainer_email'
+]
+
+
+def remove_pii_from_list(search_results):
+    for element in search_results['results']:
+        remove_pii(element)
+    return search_results
+
+
+def remove_pii(element):
+    for key in element.keys():
+        if key in PII_LIST:
+            del element[key]
+    return element

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -163,7 +163,9 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         return dict(
             resource_create=ckanext.datagovuk.action.create.resource_create,
             user_create=ckanext.datagovuk.action.create.user_create,
-            user_auth=ckanext.datagovuk.action.get.user_auth
+            user_auth=ckanext.datagovuk.action.get.user_auth,
+            package_search=ckanext.datagovuk.action.get.dgu_package_search,
+            package_show=ckanext.datagovuk.action.get.dgu_package_show,
         )
 
     # IValidators

--- a/ckanext/datagovuk/tests/action/test_get.py
+++ b/ckanext/datagovuk/tests/action/test_get.py
@@ -1,0 +1,189 @@
+import unittest
+
+from ckanext.datagovuk.action.get import remove_pii_from_list, remove_pii, PII_LIST
+
+
+sample_package_search_result = {
+    "count": 1,
+    "sort": "score desc, metadata_modified desc",
+    "facets": {},
+    "results": [
+        {
+            "license_title": "Creative Commons Attribution",
+            "maintainer": None,
+            "contact-phone": "",
+            "relationships_as_object": [],
+            "private": False,
+            "maintainer_email": None,
+            "num_tags": 0,
+            "organization": {
+                "description": "",
+                "created": "2019-08-28T12:00:00",
+                "title": "test",
+                "name": "test",
+                "is_organization": True,
+                "state": "active",
+                "image_url": "",
+                "revision_id": "revision_id",
+                "type": "organization",
+                "id": "org_id",
+                "approval_status": "approved"
+            },
+            "foi-email": "test-foi@example.com",
+            "id": "data_id",
+            "metadata_created": "2019-08-28T11:00:00",
+            "licence-custom": "",
+            "metadata_modified": "2019-08-28T11:00:00",
+            "author": None,
+            "author_email": None,
+            "state": "active",
+            "version": None,
+            "license_id": "cc-by",
+            "foi-web": "",
+            "resources": [
+                {
+                    "mimetype": None,
+                    "cache_url": None,
+                    "hash": "",
+                    "description": "",
+                    "name": "Example dataset",
+                    "format": "",
+                    "url": "https://example.com/datasets/dataset_id",
+                    "datafile-date": "",
+                    "cache_last_updated": None,
+                    "resource-type": "data-link",
+                    "package_id": "dataset_id",
+                    "created": "2019-08-28T12:00:00",
+                    "state": "active",
+                    "mimetype_inner": None,
+                    "last_modified": None,
+                    "position": 0,
+                    "revision_id": "revision_id",
+                    "url_type": None,
+                    "id": "resource_id",
+                    "resource_type": None,
+                    "size": None
+                }
+            ],
+            "num_resources": 1,
+            "contact-email": "test@example.com",
+            "tags": [],
+            "foi-name": "",
+            "groups": [],
+            "creator_user_id": "user_id",
+            "relationships_as_subject": [],
+            "codelist": "",
+            "contact-name": "Test User",
+            "name": "test",
+            "isopen": True,
+            "schema-vocabulary": "",
+            "url": None,
+            "type": "dataset",
+            "notes": "",
+            "owner_org": "org_id",
+            "license_url": "http://www.opendefinition.org/licenses/cc-by",
+            "title": "test",
+            "revision_id": "revision_id",
+            "foi-phone": "",
+            "theme-primary": ""
+        }
+    ],
+    "search_facets": {}
+}
+
+sample_package_show_result = {
+    "license_title": "Creative Commons Attribution",
+    "maintainer": None,
+    "contact-phone": "",
+    "relationships_as_object": [],
+    "private": False,
+    "maintainer_email": None,
+    "num_tags": 0,
+    "organization": {
+        "description": "",
+        "created": "2019-08-28T12:00:00",
+        "title": "test",
+        "name": "test",
+        "is_organization": True,
+        "state": "active",
+        "image_url": "",
+        "revision_id": "revision_id",
+        "type": "organization",
+        "id": "org_id",
+        "approval_status": "approved"
+    },
+    "foi-email": "test-foi@example.com",
+    "id": "id",
+    "metadata_created": "2019-08-28T11:00:00",
+    "licence-custom": "",
+    "metadata_modified": "2019-08-28T11:00:00",
+    "author": None,
+    "author_email": None,
+    "state": "active",
+    "version": None,
+    "license_id": "cc-by",
+    "foi-web": "",
+    "resources": [
+        {
+            "mimetype": None,
+            "cache_url": None,
+            "hash": "",
+            "description": "",
+            "name": "Example",
+            "format": "",
+            "url": "https://example.com/datasets/dataset_id",
+            "datafile-date": "",
+            "cache_last_updated": None,
+            "resource-type": "data-link",
+            "package_id": "dataset_id",
+            "created": "2019-08-28T11:00:00",
+            "state": "active",
+            "mimetype_inner": None,
+            "last_modified": None,
+            "position": 0,
+            "revision_id": "revision_id",
+            "url_type": None,
+            "id": "resource_id",
+            "resource_type": None,
+            "size": None
+        }
+    ],
+    "num_resources": 1,
+    "contact-email": "test@example.com",
+    "tags": [],
+    "foi-name": "",
+    "groups": [],
+    "creator_user_id": "user_id",
+    "relationships_as_subject": [],
+    "codelist": "",
+    "contact-name": "Test User",
+    "name": "test",
+    "isopen": True,
+    "schema-vocabulary": "",
+    "url": None,
+    "type": "dataset",
+    "notes": "",
+    "owner_org": "owner_id",
+    "license_url": "http://www.opendefinition.org/licenses/cc-by",
+    "title": "test",
+    "revision_id": "revision_id",
+    "foi-phone": "",
+    "theme-primary": ""
+}
+
+
+class TestRemovePII(unittest.TestCase):
+    def test_removes_pii_from_package_search(self):
+        res = remove_pii_from_list(sample_package_search_result)
+        assert not any(elem in PII_LIST for elem in res)
+
+    def test_removes_pii_from_package_show(self):
+        res = remove_pii(sample_package_show_result.copy())
+        assert not any(elem in PII_LIST for elem in res)
+
+    def test_removes_pii_works_even_if_pii_element_doesnt_exist(self):
+        modified_sample_package_show_result = sample_package_show_result.copy()
+        del modified_sample_package_show_result['contact-name']
+
+        res = remove_pii(modified_sample_package_show_result)
+        assert not any(elem in PII_LIST for elem in res)

--- a/ckanext/datagovuk/tests/test_pii_helpers.py
+++ b/ckanext/datagovuk/tests/test_pii_helpers.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ckanext.datagovuk.action.get import remove_pii_from_list, remove_pii, PII_LIST
+from ckanext.datagovuk.pii_helpers import remove_pii_from_list, remove_pii, PII_LIST
 
 
 sample_package_search_result = {


### PR DESCRIPTION
## What
Removes PII determined by keys defined in PII_LIST in `ckanext/datagovuk/pii_helpers.py`

`package_search` and `package_show` were overridden by copying the code over to this repo. This is in line with how this repo overrides core ckan functions and how other extensions are doing this.

## Reference

https://trello.com/c/GrO3ZtIR/1228-remove-personal-data-from-ckan-api-endpoints