### PR TITLE
Remove users block from organization_show

### DIFF
--- a/ckanext/datagovuk/action/get.py
+++ b/ckanext/datagovuk/action/get.py
@@ -1,5 +1,5 @@
 import ckan.logic.schema
-from ckan.logic.action.get import package_search, package_show
+from ckan.logic.action.get import organization_show, package_search, package_show
 from ckan.plugins.toolkit import (
     abort,
     check_access,
@@ -75,3 +75,9 @@ def dgu_package_search(context, data_dict):
 @side_effect_free
 def dgu_package_show(context, data_dict):
     return remove_pii(package_show(context, data_dict))
+
+
+@side_effect_free
+def dgu_organization_show(context, data_dict):
+    data_dict['include_users'] = False
+    return remove_pii(organization_show(context, data_dict))

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -166,6 +166,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             user_auth=ckanext.datagovuk.action.get.user_auth,
             package_search=ckanext.datagovuk.action.get.dgu_package_search,
             package_show=ckanext.datagovuk.action.get.dgu_package_show,
+            organization_show=ckanext.datagovuk.action.get.dgu_organization_show,
         )
 
     # IValidators


### PR DESCRIPTION
## What

Remove the users block from `organization_show` endpoint to prevent exposure of hashed emails and user names.

I've carried out an end to end test locally up to the Find app and it appears to be working.

## Reference 

https://trello.com/c/ukgvMRf4/1246-remove-users-block-from-ckan-api-organizationshow-endpoint