### PR TITLE
Remove PII from /api/3/search/dataset

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -194,6 +194,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             m.connect('/user/reset', action='request_reset')
         route_map.connect('healthcheck', '/healthcheck', controller=healthcheck_controller, action='healthcheck')
         route_map.connect('/api/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')
+        route_map.connect('/api/3/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')
         route_map.redirect('/home', '/')
         return route_map
 


### PR DESCRIPTION
## What

As puppet allows api calls with and without the version number we need to remove PII from the versioned API call.