### PR TITLE
Update package_schema to ignore harvest element

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -73,7 +73,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             })
 
         from ckan.logic.schema import default_extras_schema
-        from ckan.lib.navl.validators import not_empty
+        from ckan.lib.navl.validators import ignore, not_empty
         from ckanext.datagovuk.logic.validators import extra_key_not_in_root_schema
 
         extras_schema = default_extras_schema()
@@ -89,6 +89,14 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             'resource-type': [toolkit.get_validator('ignore_missing')],
             'datafile-date': [toolkit.get_validator('ignore_missing')],
         })
+
+        # was expecting:
+        #   schema['harvest'] = [ignore]
+        # to work but it doesn't prevent `harvest` from being added to
+        # `__junk` which will cause updates on datasets to fail
+        # See the issue on CKAN - https://github.com/ckan/ckan/issues/4989
+        # as there may be better ways to resolve this issue
+        schema['harvest'] = {'_': ignore}
 
         return schema
 

--- a/ckanext/datagovuk/tests/test_plugin.py
+++ b/ckanext/datagovuk/tests/test_plugin.py
@@ -1,7 +1,37 @@
 """Tests for plugin.py."""
+import unittest
+
+from ckan.lib.navl.dictization_functions import augment_data
+from ckan.lib.navl.validators import ignore
+
 from ckanext.datagovuk.plugin import DatagovukPlugin
 from ckanext.datagovuk.action import create, get
-import unittest
+
+sample_data = {
+    ('extras', 0, u'id'): u'test-id',
+    ('name',): u'test-package',
+    ('extras', 1, u'id'): u'test-id',
+    ('extras', 1, u'key'): u'access_constraints',
+    ('extras', 0, u'value'): u'True',
+    ('id',): u'test-dataset-id',
+    ('harvest', 0, 'key'): 'harvest_object_id',
+    ('harvest', 0, 'value'): u'harvest_obj_val',
+    ('harvest', 1, 'key'): 'harvest_source_id',
+    ('harvest', 1, 'value'): u'harvest_source_id_val',
+    ('harvest', 2, 'key'): 'harvest_source_title',
+    ('harvest', 2, 'value'): u'harvest_source_title_val',
+}
+
+sample_data_invalid = {
+    ('extras', 0, u'id'): u'test-id',
+    ('name',): u'test-package',
+    ('extras', 1, u'id'): u'test-id',
+    ('extras', 1, u'key'): u'access_constraints',
+    ('extras', 0, u'value'): u'True',
+    ('id',): u'test-dataset-id',
+    ('invalid', 0, 'key'): 'invalid_id',
+    ('invalid', 0, 'value'): u'invalid_id_val',
+}
 
 
 class TestPlugin(unittest.TestCase):
@@ -11,3 +41,18 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(action_mapping['resource_create'], create.resource_create)
         self.assertEqual(action_mapping['user_create'], create.user_create)
         self.assertEqual(action_mapping['user_auth'], get.user_auth)
+
+    def test_plugin_schema_update(self):
+        package_schema = DatagovukPlugin().update_package_schema()
+        data = augment_data(sample_data, package_schema)
+
+        assert ('__junk',) not in data
+
+    def test_plugin_schema_update_invalid(self):
+        package_schema = DatagovukPlugin().update_package_schema()
+
+        data = augment_data(sample_data_invalid, package_schema)
+
+        assert ('__junk',) in data
+        assert ('invalid', 0, 'key') in data[('__junk',)]
+        assert ('invalid', 0, 'value') in data[('__junk',)]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.0.1',
+    version='0.1.0',
 
     description='''datagovuk prototype/alpha extension''',
     long_description=long_description,


### PR DESCRIPTION
## What

Users were unable to update harvested datasets and got this error on the ckan publisher - 

```
The form contains invalid entries:

junk: The input field [('harvest', 0, 'value'), ('harvest', 0, 'key'), ('harvest', 1, 'value'), ('harvest', 2, 'value'), ('harvest', 1, 'key'), ('harvest', 2, 'key')] was not expected.
```

This was eventually traced to `augment_data` function which would check if any additional fields were added to the package dict. 

I was expecting `schema['harvest'] = [ignore]` to inform ckan to ignore that field but that didn't work, a work around was found that does work - `schema['harvest'] = {'_': ignore}`

An issue was created in ckan to see if there is a better way of doing this - https://github.com/ckan/ckan/issues/4989 or for the ckan team to improve their docs or fix the code to get it to work as expected.

## Reference

https://trello.com/c/zYenqUpG/1263-error-when-editing-data-source-on-datagovuk