### PR TITLE
Update dependencies to spatial commit 8c4189

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,7 @@ ckan_dcat_fork='alphagov'
 ckan_dcat_sha='6253f296c6d1200465a3223710d076cd24e37834'
 
 ckan_spatial_fork='alphagov'
-ckan_spatial_sha='fdae140d4bd84665062c461ce3d4fba5c75ad526'
+ckan_spatial_sha='8c4189e55e70544fbd366259d8f6f8dbb5ce6f74'
 
 ckan_s3_resources_fork='alphagov'
 ckan_s3_resources_sha='81eb36fb51da5e216e9405a7ad64c4096881ca85'


### PR DESCRIPTION
## What

Add errors from WMS check in `ckanext-spatial` to be reported back to users on ckan publisher.

## Reference 

https://trello.com/c/QzELjbIB/1310-5-investigate-why-the-format-for-some-spatial-datasets-are-not-populated-and-fix-it