### PR TITLE
Add warnings about personal information

### DIFF
--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -104,8 +104,10 @@
     <input type="text" id="field-foi-phone" name="foi-phone" value="{{ data.get('foi-phone','') }}">
   </div>
 </div>
+<div class="control-group">
+  {{ _("Metadata fields from datasets will be publicly available to users - including (where provided to us) personal information such as contact details for responsible parties.") }}
+</div>
 {% endblock %}
 
 {% block package_metadata_fields_version %}
 {% endblock %}
-

--- a/ckanext/datagovuk/templates/source/new_source_form.html
+++ b/ckanext/datagovuk/templates/source/new_source_form.html
@@ -74,6 +74,10 @@
     </div>
   {% endif %}
 
+  <div class="control-group">
+    {{ _("Metadata fields from harvested datasets will be publicly available to users - including (where provided to us) personal information such as contact details for responsible parties.") }}
+  </div>
+
   {% if data.get('id', None) and h.check_access('harvest_source_delete', {'id': data.id}) and data.get('state', 'none') == 'deleted' %}
     <div class="control-group">
       <label for="field-state" class="control-label">{{ _('State') }}</label>


### PR DESCRIPTION
There's a feeling that publishers might not be aware of where the data they enter will be displayed. The GDS Privacy Team want us to add these warnings - that will make them more comfortable showing data from these fields.

### Dataset

<img width="714" alt="Screenshot 2019-10-18 at 08 34 31" src="https://user-images.githubusercontent.com/510498/67074973-2af12500-f182-11e9-8b68-0d6c5116388d.png">

### Harvest Source

<img width="689" alt="Screenshot 2019-10-18 at 08 34 39" src="https://user-images.githubusercontent.com/510498/67074974-2af12500-f182-11e9-9c19-fcabd4c96989.png">

[Trello Card](https://trello.com/c/dD6rWy3M/1431-5-add-more-warnings-for-publishers-about-personal-data-%F0%9F%8D%90)