### PR TITLE
Remove contact details from PII exclusion list

### DIFF
--- a/ckanext/datagovuk/pii_helpers.py
+++ b/ckanext/datagovuk/pii_helpers.py
@@ -3,9 +3,6 @@ import json
 PII_LIST = [
     'author',
     'author_email',
-    'contact-name',
-    'contact-phone',
-    'contact-email',
     'maintainer',
     'maintainer_email'
 ]


### PR DESCRIPTION
These contact details are not PII and may be shown.

[Trello](https://trello.com/c/h7vAgmX9/1430-3-show-contact-details-for-datasets%F0%9F%8D%90)