### PR TITLE
Update spatial sha to 24fcbc

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,7 @@ ckan_dcat_fork='alphagov'
 ckan_dcat_sha='6253f296c6d1200465a3223710d076cd24e37834'
 
 ckan_spatial_fork='alphagov'
-ckan_spatial_sha='43f27a61b856b7d5ffaf88eb65452e2d6ada8f74'
+ckan_spatial_sha='24fcbc896149b5a10d754adb534873bcad46fc4e'
 
 ckan_s3_resources_fork='alphagov'
 ckan_s3_resources_sha='81eb36fb51da5e216e9405a7ad64c4096881ca85'


### PR DESCRIPTION
## What

Update the `ckanext-spatial` sha to enable better logging when duplicate GUIDs are in the same harvest source, and prevent datasets from being silently overwritten.