### PR TITLE
Update dependencies to use spatial b86a7

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,7 @@ ckan_dcat_fork='alphagov'
 ckan_dcat_sha='6253f296c6d1200465a3223710d076cd24e37834'
 
 ckan_spatial_fork='alphagov'
-ckan_spatial_sha='24fcbc896149b5a10d754adb534873bcad46fc4e'
+ckan_spatial_sha='b86a7189577285169b0cb5ed93f145387debeec6'
 
 ckan_s3_resources_fork='alphagov'
 ckan_s3_resources_sha='81eb36fb51da5e216e9405a7ad64c4096881ca85'


### PR DESCRIPTION
## What

The spatial update fixes a bug to handle datasets that do not have the source url information as part of a check on duplicate guids within a harvest source.