### PR TITLE
Use spatial sha with upstream commits

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,7 @@ ckan_dcat_fork='alphagov'
 ckan_dcat_sha='6253f296c6d1200465a3223710d076cd24e37834'
 
 ckan_spatial_fork='alphagov'
-ckan_spatial_sha='b86a7189577285169b0cb5ed93f145387debeec6'
+ckan_spatial_sha='0ba6e7951e55fbdbdbf7e31d0d78113d3d780d43'
 
 ckan_s3_resources_fork='alphagov'
 ckan_s3_resources_sha='81eb36fb51da5e216e9405a7ad64c4096881ca85'

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -3,7 +3,7 @@
 pip=${1-'/usr/bin/env pip'}
 
 ckan_harvest_fork='alphagov'
-ckan_harvest_sha='3fff71408d184cc18978203211b88f7153a0f0f5'
+ckan_harvest_sha='5507adc82585a273c51eaebdf7e1d3bbe7d0f9dc'
 
 ckan_dcat_fork='alphagov'
 ckan_dcat_sha='6253f296c6d1200465a3223710d076cd24e37834'


### PR DESCRIPTION
## What

We can deploy with the updated sha which is linked to the commit in spatial without it being merged into spatial master as there may be other changes we will need to make on spatial to get it merged upstream.