### PR TITLE
Updates the environment agency email

### DIFF
--- a/migrations/003_update_environment_agency_contact_email.sql
+++ b/migrations/003_update_environment_agency_contact_email.sql
@@ -1,0 +1,14 @@
+-- To trigger the update in Publish the modified date needs to be later than the one in the Publish DB
+
+BEGIN TRANSACTION;
+
+UPDATE package SET metadata_modified = '2020-01-22' WHERE id IN (
+    SELECT package_id FROM package_extra
+    WHERE key = 'contact-email' AND
+    value = 'data.info@environment-agency.gov.uk'
+);
+
+UPDATE package_extra SET value = 'DSPcustomerforum@environment-agency.gov.uk' 
+WHERE key = 'contact-email' AND value = 'data.info@environment-agency.gov.uk';
+
+COMMIT;


### PR DESCRIPTION
## What

Environment Agency has requested that the contact email for harvest sources that have retired be updated as they are unable to update them. 

## Reference 

https://trello.com/c/LVndkOcl/1665-bulk-update-environment-agency-enquiries-email-across-datagovuk