### PR TITLE
Patch guess_group_type for /publisher routes

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -216,6 +216,13 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         harvest_org_controller = 'ckanext.harvest.controllers.organization:OrganizationController'
         route_map.connect('harvest_org_list', '/publisher/harvest/' + '{id}', controller=harvest_org_controller, action='source_list')
 
+        # add this function in OrganizationController as CKAN doesn't have 'publisher' group type
+        def _guess_group_type(self, expecting_name=False):
+            return 'organization'
+        
+        from ckan.controllers.organization import OrganizationController
+        OrganizationController._guess_group_type = _guess_group_type
+
         # Recreates the organization routes with /publisher instead.
         with SubMapper(route_map, controller='organization') as m:
             m.connect('organizations_index', '/publisher', action='index')

--- a/ckanext/datagovuk/tests/test_paths.py
+++ b/ckanext/datagovuk/tests/test_paths.py
@@ -1,7 +1,8 @@
+from bs4 import BeautifulSoup
+import unittest
 import ckan.plugins.toolkit as toolkit
 import ckan.tests.helpers as helpers
 import ckanext.datagovuk.plugin as plugin
-import unittest
 
 
 class TestPaths(unittest.TestCase):
@@ -28,3 +29,23 @@ class TestPaths(unittest.TestCase):
 
         assert resp.status_int == 302
         assert resp.location == 'http://localhost/'
+
+
+    def test_publisher_path(self):
+        ''' The test client from core CKAN is not picking up the internationalization
+            strings locally which is why it's showing `Organizations` and not
+            'Publishers'
+        '''
+        app = helpers._get_test_app()
+        resp = app.get('/publisher')
+        assert resp.status_int == 200
+
+        page = BeautifulSoup(resp.html.decode('utf-8'), 'html.parser')
+
+        assert page.h1.text.strip() == (
+            'Organizations'
+        )
+
+        assert page.ol.li.find_next("li").a.text.strip() == (
+            'Organizations'
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 awesome-slugify==1.6.5
+beautifulsoup4==4.8.1
 blinker==1.4
 boto3==1.4.3
 gunicorn


### PR DESCRIPTION
This was removed 2 years ago from core CKAN but is required for us
to route to organisations correctly. See ckan/ckan@e397e4c#diff-d48c332d8b78785e88afaf8406c9fff3

This patch also means we can defer the work on upgrading the pages
to flask views.

Trello card: https://trello.com/c/dljuAYRk/1691-5-fix-publisher-form-in-datagovuk-extension-in-docker-ckan-28-%F0%9F%8D%90