### PR TITLE
Fix upload timestamp

### DIFF
--- a/ckanext/datagovuk/action/create.py
+++ b/ckanext/datagovuk/action/create.py
@@ -15,6 +15,7 @@ import ckan.lib.dictization.model_dictize as model_dictize
 from ckan.logic.action.create import resource_create as resource_create_core
 from ckan.logic import get_or_bust
 from ckanext.datagovuk.lib.organogram_xls_splitter import create_organogram_csvs
+from ckanext.datagovuk.upload import upload_resource_to_s3
 
 
 log = __import__('logging').getLogger(__name__)
@@ -80,7 +81,10 @@ def resource_create(context, data_dict):
                 timestamp_str = timestamp.strftime("%Y-%m-%dT%H-%M-%SZ")
 
                 senior_resource = _create_csv_resource('Senior', senior_csv, data_dict.copy(), context, timestamp_str)
+                upload_resource_to_s3(context, senior_resource)
+
                 junior_resource = _create_csv_resource('Junior', junior_csv, data_dict.copy(), context, timestamp_str)
+                upload_resource_to_s3(context, junior_resource)
 
                 return senior_resource
 

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -284,6 +284,8 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             sentry_sdk.init(integrations=[FlaskIntegration()])
             return app
 
+    # IResourceController
+
     def before_create_or_update(self, context, resource):
         """before_create_or_update - our own function. NOT a CKAN hook.
         Contains shared code performed regardless of whether we are
@@ -301,8 +303,6 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
                 "Required S3 config options missing. Please check if required config options exist."
             )
             raise KeyError("Required S3 config options missing")
-        else:
-            upload.upload_resource_to_s3(context, resource)
 
     def before_create(self, context, resource):
         """Runs before resource_create. Modifies resource destructively to put in the S3 URL"""

--- a/ckanext/datagovuk/tests/test_s3_resources_plugin.py
+++ b/ckanext/datagovuk/tests/test_s3_resources_plugin.py
@@ -1,139 +1,42 @@
 #!/usr/bin/env python3
-import cgi
-from StringIO import StringIO
+import unittest
+from mock import patch
 
-import pylons.config as config
-from botocore.exceptions import ClientError
 from ckanext.datagovuk.plugin import DatagovukPlugin
-from mock import Mock, patch
 from nose.tools import assert_raises
 
 
-class MockAction:
-    def __init__(self, _type):
-        self._type = _type
+class TestS3ResourcesPlugin(unittest.TestCase):
+    plugin = DatagovukPlugin()
 
-    def __call__(self, *arg):
-        if self._type == "package_show":
-            return {"name": "test"}
-
-
-@patch.dict(
-    "pylons.config",
-    {
-        "ckan.datagovuk.s3_aws_access_key_id": "key-id",
-        "ckan.datagovuk.s3_aws_secret_access_key": "secret-key",
-        "ckan.datagovuk.s3_bucket_name": "test-bucket",
-        "ckan.datagovuk.s3_url_prefix": "https://s3.amazonaws.com/test/",
-        "ckan.datagovuk.s3_aws_region_name": "eu-west-1",
-    },
-)
-class TestS3ResourcesPlugin:
-    upload = cgi.FieldStorage()
-    upload.file = StringIO("hello world")
-    resource = {
-        "package_id": u"some-pointless-data-3",
-        "clear_upload": u"",
-        "url": "organogram-senior.csv",
-        "timestamp": "2020-01-09T12-11-41Z",
-        "datafile-date": u"",
-        "upload": upload,
-        "name": "2020-01-09 Organogram (Senior)",
-    }
-
-    @patch.dict("pylons.config", {}, clear=True)
     def test_s3_config_exception(self):
-        plugin = DatagovukPlugin()
         with assert_raises(KeyError) as context:
-            plugin.before_create_or_update({}, {"upload": "dummy value"})
+            self.plugin.before_create_or_update({}, {"upload": "dummy value"})
 
         assert context.exception.message == "Required S3 config options missing"
 
-    @patch("boto3.resource")
-    @patch("ckanext.datagovuk.upload.toolkit.abort")
-    @patch("ckanext.datagovuk.upload.toolkit")
-    def test_before_create_or_update(self, mock_toolkit, mock_abort, mock_resource):
-        mock_toolkit.get_action = MockAction
+    @patch("ckanext.datagovuk.plugin.upload.config_exists")
+    def test_upload_early_abort(self, mock_check_config):
+        resource = {
+            "package_id": u"some-pointless-data-1",
+            "url": "organogram-senior.csv",
+            "timestamp": "2020-01-09T12-11-41Z",
+            "name": "2020-01-09 Organogram (Senior)",
+        }
 
-        plugin = DatagovukPlugin()
-        resource = self.resource.copy()
+        self.plugin.before_create_or_update({}, resource)
+        assert not mock_check_config.called
 
-        plugin.before_create_or_update({}, resource)
-        assert not mock_abort.called
-        assert config.get("ckan.datagovuk.s3_url_prefix") in resource["url"]
+    @patch("ckanext.datagovuk.plugin.upload.config_exists")
+    def test_format_api_early_abort(self, mock_check_config):
+        resource = {
+            "package_id": u"some-pointless-data-1",
+            "url": "organogram-senior.csv",
+            "timestamp": "2020-01-09T12-11-41Z",
+            "name": "2020-01-09 Organogram (Senior)",
+            "format": "API",
+            "upload": "test.csv"
+        }
 
-    @patch("boto3.resource")
-    @patch("ckanext.datagovuk.upload.toolkit.abort")
-    @patch("ckanext.datagovuk.upload.toolkit")
-    def test_before_create_or_update_empty_upload(
-        self, mock_toolkit, mock_abort, mock_resource
-    ):
-        mock_toolkit.get_action = MockAction
-
-        plugin = DatagovukPlugin()
-        resource = self.resource.copy()
-        resource["upload"] = ""
-
-        plugin.before_create_or_update({}, resource)
-        assert not mock_abort.called
-        assert config.get("ckan.datagovuk.s3_url_prefix") not in resource["url"]
-
-    @patch("boto3.resource")
-    @patch("ckanext.datagovuk.upload.toolkit.abort")
-    @patch("ckanext.datagovuk.upload.toolkit")
-    def test_before_create_or_update_undefined_upload(
-        self, mock_toolkit, mock_abort, mock_resource
-    ):
-        mock_toolkit.get_action = MockAction
-
-        plugin = DatagovukPlugin()
-        resource = self.resource.copy()
-        del resource["upload"]
-
-        plugin.before_create_or_update({}, resource)
-        assert not mock_abort.called
-        assert config.get("ckan.datagovuk.s3_url_prefix") not in resource["url"]
-
-    @patch("boto3.resource")
-    @patch("ckanext.datagovuk.upload.toolkit.abort")
-    @patch("ckanext.datagovuk.upload.toolkit")
-    def test_before_create_or_update_upload_api(
-        self, mock_toolkit, mock_abort, mock_resource
-    ):
-        mock_toolkit.get_action = MockAction
-
-        plugin = DatagovukPlugin()
-        resource = self.resource.copy()
-        resource["format"] = "API"
-
-        plugin.before_create_or_update({}, resource)
-        assert not mock_abort.called
-        assert config.get("ckan.datagovuk.s3_url_prefix") not in resource["url"]
-
-    @patch("boto3.resource")
-    @patch("ckanext.datagovuk.upload.toolkit.abort")
-    @patch("ckanext.datagovuk.upload.toolkit")
-    def test_upload_early_abort(self, mock_toolkit, mock_abort, mock_resource):
-        mock_toolkit.get_action = MockAction
-
-        plugin = DatagovukPlugin()
-        resource = self.resource.copy()
-        resource["upload"] = "dummy data"  # *not* a FieldStorage
-
-        plugin.before_create_or_update({}, resource)
-        assert not mock_abort.called
-        assert config.get("ckan.datagovuk.s3_url_prefix") not in resource["url"]
-
-    @patch("botocore.client.BaseClient._make_api_call")
-    @patch("ckanext.datagovuk.upload.toolkit.abort")
-    @patch("ckanext.datagovuk.upload.toolkit")
-    def test_upload_s3_exception(self, mock_toolkit, mock_abort, mock_api_call):
-        mock_toolkit.get_action = MockAction
-        mock_api_call.side_effect = ClientError({"Error": {}}, "Unknown")
-
-        plugin = DatagovukPlugin()
-        resource = self.resource.copy()
-
-        with assert_raises(ClientError):
-            plugin.before_create_or_update({}, resource)
-        assert config.get("ckan.datagovuk.s3_url_prefix") not in resource["url"]
+        self.plugin.before_create_or_update({}, resource)
+        assert not mock_check_config.called

--- a/ckanext/datagovuk/tests/test_upload.py
+++ b/ckanext/datagovuk/tests/test_upload.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import cgi
+from StringIO import StringIO
+import unittest
+
+import pylons.config as config
+from botocore.exceptions import ClientError
+from ckanext.datagovuk.plugin import DatagovukPlugin
+from ckanext.datagovuk.upload import upload_resource_to_s3
+from mock import Mock, patch
+from nose.tools import assert_raises
+
+
+class MockAction:
+    def __init__(self, _type):
+        self._type = _type
+
+    def __call__(self, *arg):
+        if self._type == "package_show":
+            return {"name": "test"}
+
+
+@patch.dict(
+    "pylons.config",
+    {
+        "ckan.datagovuk.s3_aws_access_key_id": "key-id",
+        "ckan.datagovuk.s3_aws_secret_access_key": "secret-key",
+        "ckan.datagovuk.s3_bucket_name": "test-bucket",
+        "ckan.datagovuk.s3_url_prefix": "https://s3.amazonaws.com/test/",
+        "ckan.datagovuk.s3_aws_region_name": "eu-west-1",
+    },
+)
+class TestUpload(unittest.TestCase):
+    upload = cgi.FieldStorage()
+    upload.file = StringIO("hello world")
+    resource = {
+        "package_id": u"some-pointless-data-1",
+        "clear_upload": u"",
+        "url": "organogram-senior.csv",
+        "timestamp": "2020-01-09T12-11-41Z",
+        "datafile-date": u"",
+        "upload": upload,
+        "name": "2020-01-09 Organogram (Senior)",
+    }
+
+    @patch("ckanext.datagovuk.upload.update_timestamp")
+    @patch("boto3.resource")
+    @patch("ckanext.datagovuk.upload.toolkit.abort")
+    @patch("ckanext.datagovuk.upload.toolkit")
+    def test_upload(self, mock_toolkit, mock_abort, mock_resource, mock_update_timestamp):
+        mock_toolkit.get_action = MockAction
+
+        resource = self.resource.copy()
+
+        upload_resource_to_s3({}, resource)
+        assert not mock_abort.called
+        assert config.get("ckan.datagovuk.s3_url_prefix") in resource["url"]
+        assert mock_update_timestamp.called
+
+    @patch("ckanext.datagovuk.upload.update_timestamp")
+    @patch("boto3.resource")
+    @patch("ckanext.datagovuk.upload.toolkit")
+    def test_upload_url_doesnt_upload_to_s3(self, mock_toolkit, mock_resource, mock_update_timestamp):
+        mock_toolkit.get_action = MockAction
+
+        resource = self.resource.copy()
+        resource['url'] = "http://example.com/test.csv"
+        del resource["upload"]
+
+        upload_resource_to_s3({}, resource)
+        assert not mock_update_timestamp.called
+
+    @patch("botocore.client.BaseClient._make_api_call")
+    @patch("ckanext.datagovuk.upload.toolkit")
+    def test_upload_s3_exception(self, mock_toolkit, mock_api_call):
+        mock_toolkit.get_action = MockAction
+        mock_api_call.side_effect = ClientError({"Error": {}}, "Unknown")
+
+        resource = self.resource.copy()
+
+        with assert_raises(ClientError):
+            upload_resource_to_s3({}, resource)
+        assert config.get("ckan.datagovuk.s3_url_prefix") not in resource["url"]


### PR DESCRIPTION
## What

The timestamps in the filenames were different for senior and junior csv files which meant that the frontend was not able to find the files. 

This fixes the timestamp to be the same for junior and senior csv files.

## Reference 

https://trello.com/c/Q7t5BErs/1742-fix-timestamp-when-uploading-organogram-in-ckanext-datagovuk