### PR TITLE
Fix s3 filename

### DIFF
--- a/ckanext/datagovuk/action/create.py
+++ b/ckanext/datagovuk/action/create.py
@@ -81,11 +81,7 @@ def resource_create(context, data_dict):
                 timestamp_str = timestamp.strftime("%Y-%m-%dT%H-%M-%SZ")
 
                 senior_resource = _create_csv_resource('Senior', senior_csv, data_dict.copy(), context, timestamp_str)
-                upload_resource_to_s3(context, senior_resource)
-
                 junior_resource = _create_csv_resource('Junior', junior_csv, data_dict.copy(), context, timestamp_str)
-                upload_resource_to_s3(context, junior_resource)
-
                 return senior_resource
 
     log.debug("Passing args through to the CKAN resource_create")
@@ -105,6 +101,7 @@ def _create_csv_resource(junior_senior, csv, resource_data, context, timestamp):
     resource_data['upload'] = csv_wrapper
     resource_data['timestamp'] = timestamp
 
+    upload_resource_to_s3(context, resource_data)
     return resource_create_core(context, resource_data)
 
 

--- a/ckanext/datagovuk/tests/action/test_create.py
+++ b/ckanext/datagovuk/tests/action/test_create.py
@@ -121,7 +121,7 @@ class TestWhenValidOrganogramXlsFile(TestResourceCreate):
             'upload': self.data_dict
         }
 
-        helpers.call_action('resource_create', self.context, **self.data_dict)
+        create.resource_create(self.context, self.data_dict)
 
         assert mock_resource_create.call_args_list[0][0][1]['timestamp'] == \
             mock_resource_create.call_args_list[1][0][1]['timestamp']

--- a/ckanext/datagovuk/tests/test_upload.py
+++ b/ckanext/datagovuk/tests/test_upload.py
@@ -55,6 +55,7 @@ class TestUpload(unittest.TestCase):
         upload_resource_to_s3({}, resource)
         assert not mock_abort.called
         assert config.get("ckan.datagovuk.s3_url_prefix") in resource["url"]
+        assert resource["url"].endswith("organogram-senior.csv")
         assert mock_update_timestamp.called
 
     @patch("ckanext.datagovuk.upload.update_timestamp")

--- a/ckanext/datagovuk/upload.py
+++ b/ckanext/datagovuk/upload.py
@@ -83,7 +83,7 @@ def upload_resource_to_s3(context, resource):
         + extension
     )
 
-    s3_filepath = "/".join([pkg.get("name"), "resources", filename]) + extension
+    s3_filepath = "/".join([pkg.get("name"), "resources", filename])
 
     # If file is currently being uploaded, the file is in resource['upload']
     if isinstance(resource.get('upload'), cgi.FieldStorage):


### PR DESCRIPTION
## What 

The s3 url contained a filename with an additional extension which meant that the javascript code to visualise an organogram failed to work.

Also the upload resource was moved so that the settings following an upload would be correctly set.

## Why

Fixes organogram visualisation

## Reference 

https://trello.com/c/Q7t5BErs/1742-fix-timestamp-when-uploading-organogram-in-ckanext-datagovuk