### PR TITLE
Add additional tests for 2.8

### DIFF
--- a/ckanext/datagovuk/tests/test_package.py
+++ b/ckanext/datagovuk/tests/test_package.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from mock import patch
 from routes import url_for
 
 import ckan.plugins
@@ -55,7 +56,8 @@ class TestPackageController(helpers.FunctionalTestBase, DBTest):
 
 
     ## Test organogram file upload
-    def test_resource_create_organogram_file_upload(self):
+    @patch("ckan.lib.helpers.uploader.get_storage_path", return_value='./')
+    def test_resource_create_organogram_file_upload(self, mock_uploads_enabled):
         user = factories.User()
         organization = factories.Organization(
             users=[{'name': user['id'], 'capacity': 'admin'}]
@@ -74,7 +76,6 @@ class TestPackageController(helpers.FunctionalTestBase, DBTest):
         )
 
         page = BeautifulSoup(response.html.decode('utf-8'), 'html.parser')
-
         form = response.forms['resource-edit']
         assert not 'resource-type' in form.fields
         assert 'url' in form.fields

--- a/ckanext/datagovuk/tests/test_package.py
+++ b/ckanext/datagovuk/tests/test_package.py
@@ -84,6 +84,34 @@ class TestPackageController(helpers.FunctionalTestBase, DBTest):
         assert 'format' in form.fields
 
 
+    ## Test standard dataset file upload
+    def test_resource_create_standard_file_upload(self):
+        user = factories.User()
+        organization = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'admin'}]
+        )
+        dataset = factories.Dataset(owner_org=organization['id'])
+
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(controller='package',
+                    action='new_resource',
+                    id=dataset['name']),
+            extra_environ=env,
+        )
+
+        page = BeautifulSoup(response.html.decode('utf-8'), 'html.parser')
+
+        form = response.forms['resource-edit']
+        assert 'resource-type' in form.fields
+        assert 'url' in form.fields
+        assert not 'upload' in form.fields
+        assert 'name' in form.fields
+        assert 'datafile-date' in form.fields
+        assert 'format' in form.fields
+
+
     ## Tests for rendering the forms
 
     def test_form_renders(self):

--- a/ckanext/datagovuk/tests/test_package.py
+++ b/ckanext/datagovuk/tests/test_package.py
@@ -58,6 +58,11 @@ class TestPackageController(helpers.FunctionalTestBase, DBTest):
     ## Test organogram file upload
     @patch("ckan.lib.helpers.uploader.get_storage_path", return_value='./')
     def test_resource_create_organogram_file_upload(self, mock_uploads_enabled):
+        '''
+        This should fail in 2.8 as the `upload` button isn't showing due to a
+        javascript issue. Setting up Jasmine might help us test the forms more
+        thoroughly.
+        '''
         user = factories.User()
         organization = factories.Organization(
             users=[{'name': user['id'], 'capacity': 'admin'}]

--- a/ckanext/datagovuk/tests/test_paths.py
+++ b/ckanext/datagovuk/tests/test_paths.py
@@ -45,3 +45,15 @@ class TestPaths(unittest.TestCase):
         assert page.ol.li.find_next("li").a.text.strip() == (
             'Publishers'
         )
+
+    def test_publisher_navigation_tab(self):
+        app = helpers._get_test_app()
+        resp = app.get('/')
+        page = BeautifulSoup(resp.html.decode('utf-8'), 'html.parser')
+
+        text = page.find_all(href="/publisher")[0].text.strip()
+
+
+        assert text == (
+            'Publishers'
+        )

--- a/ckanext/datagovuk/tests/test_paths.py
+++ b/ckanext/datagovuk/tests/test_paths.py
@@ -32,10 +32,6 @@ class TestPaths(unittest.TestCase):
 
 
     def test_publisher_path(self):
-        ''' The test client from core CKAN is not picking up the internationalization
-            strings locally which is why it's showing `Organizations` and not
-            'Publishers'
-        '''
         app = helpers._get_test_app()
         resp = app.get('/publisher')
         assert resp.status_int == 200
@@ -43,9 +39,9 @@ class TestPaths(unittest.TestCase):
         page = BeautifulSoup(resp.html.decode('utf-8'), 'html.parser')
 
         assert page.h1.text.strip() == (
-            'Organizations'
+            'Publishers'
         )
 
         assert page.ol.li.find_next("li").a.text.strip() == (
-            'Organizations'
+            'Publishers'
         )

--- a/migrations-2.8.md
+++ b/migrations-2.8.md
@@ -1,0 +1,32 @@
+# Known issues migrating to 2.8
+
+## Style/layout
+
+- breadcrumb font size smaller by 2px
+- buttons don't have a `background-image` set for the gradient effect
+- form fields are not in line with labels
+- all form fields are full width due to the introduction of the `form-control`
+class on the `<input>` tag
+- validation error blocks aren't in line with related form field
+
+## Form Image URL field
+This field should have the ability of adding the image by url or upload. The
+javascript isn't loading the `Data` field as expected, and the upload field
+appears hidden on the page. This looks like an identical issue to the organogram
+dataset upload field, see below.
+
+## Creating a new resource
+
+### Format autocomplete feature not working
+In step two of creating a dataset (/dataset/new-resource), it should have the
+ability of autocompleting the `format` field when populated. It is currently
+showing a static form field - see https://github.com/alphagov/ckan/blob/master/ckan/templates/package/snippets/resource_form.html#L38-L44
+The script used to load the field is https://github.com/alphagov/ckan/blob/master/ckan/public/base/javascript/modules/autocomplete.js
+
+### Organogram dataset upload form
+
+In step two of creating a dataset (/dataset/new-resource), it should have the
+ability of adding the resource by url or upload. The javascript isn't loading the
+`Data` field as expected, and the upload field appears hidden on the page - see
+https://github.com/alphagov/ckan/blob/master/ckan/templates/package/snippets/resource_form.html#L23-L26
+The script used to load the field is https://github.com/alphagov/ckan/blob/master/ckan/public/base/javascript/modules/image-upload.js

--- a/migrations-2.8.md
+++ b/migrations-2.8.md
@@ -1,5 +1,13 @@
 # Known issues migrating to 2.8
 
+## beautifulsoup4
+
+When running the tests there might be an error such as
+`AttributeError: 'module' object has no attribute '_base'`
+
+Running `pip install --upgrade beautifulsoup4` in the Docker container should
+fix this.
+
 ## Style/layout
 
 - breadcrumb font size smaller by 2px

--- a/test.ini
+++ b/test.ini
@@ -9,14 +9,14 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../src/ckan/test-core.ini
+use = egg:ckan
 full_stack = true
 cache_dir = /tmp/beaker-test
 debug = false
 testing = true
 
 # Specify the Postgres database for SQLAlchemy to use
-sqlalchemy.url = postgres://ckan:ckan@db/ckan_test
+sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
 
 ## Datastore
 ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_test

--- a/test.ini
+++ b/test.ini
@@ -9,14 +9,14 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = egg:ckan
+use = config:../../src/ckan/test-core.ini
 full_stack = true
 cache_dir = /tmp/beaker-test
 debug = false
 testing = true
 
 # Specify the Postgres database for SQLAlchemy to use
-sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
+sqlalchemy.url = postgres://ckan:ckan@db/ckan_test
 
 ## Datastore
 ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_test
@@ -98,6 +98,13 @@ ckan.tracking_enabled = true
 
 beaker.session.key = ckan
 beaker.session.secret = This_is_a_secret_or_is_it
+
+## Internationalisation Settings
+ckan.locale_default = en_GB
+ckan.locale_order = en_GB
+ckan.locales_offered = en_GB
+ckan.locales_filtered_out = en_US
+ckan.i18n_directory = %(here)s/ckanext/datagovuk/
 
 # repoze.who config
 who.config_file = %(here)s/who.ini


### PR DESCRIPTION
These tests should help us with the upgrade to 2.8

Trello card: https://trello.com/c/GJ7FxlvE/1718-8-add-datagovuk-tests-to-capture-the-failing-parts-of-the-upgrade-to-ckan-28-%F0%9F%8D%90