### PR TITLE
Add password change email

### DIFF
--- a/ckanext/datagovuk/action/update.py
+++ b/ckanext/datagovuk/action/update.py
@@ -1,0 +1,23 @@
+from ckan.common import _
+from ckan.lib import mailer
+from ckan.logic import get_action
+from ckan.logic.action.update import user_update
+import ckan.model as model
+
+from ckanext.datagovuk.lib.mailer import send_password_alert
+
+log = __import__('logging').getLogger(__name__)
+
+
+def dgu_user_update(context, data_dict):
+    user_dict = user_update(context, data_dict)
+
+    reset_password = context.get('reset_password')
+    password_changed = 'password1' in data_dict and data_dict['password1'] != data_dict['old_password']
+
+    if reset_password or password_changed:
+        log.info('User password %s: %s', 'is being reset' if reset_password else 'has changed', data_dict['name'])
+
+        user = context['user_obj']
+        send_password_alert(user)
+    return user_dict

--- a/ckanext/datagovuk/ckan_patches/__init__.py
+++ b/ckanext/datagovuk/ckan_patches/__init__.py
@@ -1,5 +1,6 @@
 # Import all the files in this directory, so that plugin.py can just import
 # this directory and it performs all the monkey patching.
 
+from cli import *
 from logic import *
 from model import *

--- a/ckanext/datagovuk/ckan_patches/cli.py
+++ b/ckanext/datagovuk/ckan_patches/cli.py
@@ -1,0 +1,18 @@
+import ckan.lib.cli
+
+from ckanext.datagovuk.lib.mailer import send_password_alert
+
+
+def setpass(self):
+    ckan.lib.cli.UserCmd.original_setpass(self)
+
+    if len(self.args) > 1:
+        import ckan.model as model
+
+        username = self.args[1]
+        user = model.User.get(username)
+        send_password_alert(user)
+
+
+ckan.lib.cli.UserCmd.original_setpass = ckan.lib.cli.UserCmd.setpass
+ckan.lib.cli.UserCmd.setpass = setpass

--- a/ckanext/datagovuk/lib/mailer.py
+++ b/ckanext/datagovuk/lib/mailer.py
@@ -1,0 +1,13 @@
+from ckan.lib import mailer
+import ckan.model as model
+
+log = __import__('logging').getLogger(__name__)
+
+
+def send_password_alert(user):
+    try:
+        body = "Your password has been changed, if you haven't done it yourself, let us know"
+        mailer.mail_user(user, 'Your CKAN password has changed', body)
+        log.info('Sent email to alert password change')
+    except mailer.MailerException, e:
+        log.error('Could not send email to alert password change: %s' % unicode(e))

--- a/ckanext/datagovuk/lib/mailer.py
+++ b/ckanext/datagovuk/lib/mailer.py
@@ -7,7 +7,7 @@ log = __import__('logging').getLogger(__name__)
 def send_password_alert(user):
     try:
         body = "Your password has been changed, if you haven't done it yourself, let us know"
-        mailer.mail_user(user, 'Your CKAN password has changed', body)
+        mailer.mail_user(user, 'Your data.gov.uk publisher password has changed', body)
         log.info('Sent email to alert password change')
     except mailer.MailerException, e:
         log.error('Could not send email to alert password change: %s' % unicode(e))

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -10,6 +10,7 @@ import ckanext.datagovuk.auth as auth
 import ckanext.datagovuk.schema as schema_defs
 import ckanext.datagovuk.action.create
 import ckanext.datagovuk.action.get
+import ckanext.datagovuk.action.update
 import ckanext.datagovuk.upload as upload
 
 from ckanext.datagovuk.logic.theme_validator import valid_theme
@@ -173,12 +174,13 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     def get_actions(self):
         return dict(
-            resource_create=ckanext.datagovuk.action.create.resource_create,
-            user_create=ckanext.datagovuk.action.create.user_create,
-            user_auth=ckanext.datagovuk.action.get.user_auth,
+            organization_show=ckanext.datagovuk.action.get.dgu_organization_show,
             package_search=ckanext.datagovuk.action.get.dgu_package_search,
             package_show=ckanext.datagovuk.action.get.dgu_package_show,
-            organization_show=ckanext.datagovuk.action.get.dgu_organization_show,
+            resource_create=ckanext.datagovuk.action.create.resource_create,
+            user_auth=ckanext.datagovuk.action.get.user_auth,
+            user_create=ckanext.datagovuk.action.create.user_create,
+            user_update=ckanext.datagovuk.action.update.dgu_user_update,
         )
 
     # IValidators

--- a/ckanext/datagovuk/tests/action/test_update.py
+++ b/ckanext/datagovuk/tests/action/test_update.py
@@ -1,0 +1,45 @@
+from mock import patch
+
+import ckan.model as model
+from ckan.tests import factories, helpers
+from ckanext.datagovuk.action.update import dgu_user_update
+
+
+class TestWhenUpdatingUser:
+
+    def setup(self):
+        helpers.reset_db()
+
+    @patch('ckanext.datagovuk.action.update.user_update')
+    @patch('ckanext.datagovuk.lib.mailer.mailer.mail_user')
+    def test_an_email_alert_gets_sent_when_password_changes(self, mock_mailer, mock_user_update):
+        user_dict = factories.User(password='hello123')
+        user_dict.update(password1='password', old_password= 'oldpassword')
+
+        context = {
+            "user_obj": model.User.get(user_dict['name'])
+        }
+
+        dgu_user_update(context, user_dict)
+        assert mock_mailer.called
+        args, kwargs = mock_mailer.call_args
+        assert args[0].email == user_dict['email']
+        assert args[1] == 'Your CKAN password has changed'
+        assert args[2] == "Your password has been changed, if you haven't done it yourself, let us know"
+
+    @patch('ckanext.datagovuk.action.update.user_update')
+    @patch('ckanext.datagovuk.lib.mailer.mailer.mail_user')
+    def test_an_email_alert_gets_sent_when_password_resets(self, mock_mailer, mock_user_update):
+        user_dict = factories.User(password='hello123')
+
+        context = {
+            "reset_password": True,
+            "user_obj": model.User.get(user_dict['name'])
+        }
+
+        dgu_user_update(context, user_dict)
+        assert mock_mailer.called
+        args, kwargs = mock_mailer.call_args
+        assert args[0].email == user_dict['email']
+        assert args[1] == 'Your CKAN password has changed'
+        assert args[2] == "Your password has been changed, if you haven't done it yourself, let us know"

--- a/ckanext/datagovuk/tests/action/test_update.py
+++ b/ckanext/datagovuk/tests/action/test_update.py
@@ -24,7 +24,7 @@ class TestWhenUpdatingUser:
         assert mock_mailer.called
         args, kwargs = mock_mailer.call_args
         assert args[0].email == user_dict['email']
-        assert args[1] == 'Your CKAN password has changed'
+        assert args[1] == 'Your data.gov.uk publisher password has changed'
         assert args[2] == "Your password has been changed, if you haven't done it yourself, let us know"
 
     @patch('ckanext.datagovuk.action.update.user_update')
@@ -41,5 +41,5 @@ class TestWhenUpdatingUser:
         assert mock_mailer.called
         args, kwargs = mock_mailer.call_args
         assert args[0].email == user_dict['email']
-        assert args[1] == 'Your CKAN password has changed'
+        assert args[1] == 'Your data.gov.uk publisher password has changed'
         assert args[2] == "Your password has been changed, if you haven't done it yourself, let us know"

--- a/ckanext/datagovuk/tests/test_ckan_patches.py
+++ b/ckanext/datagovuk/tests/test_ckan_patches.py
@@ -55,5 +55,5 @@ class TestSetPass(DBTest):
         args, kwargs = mock_mailer.call_args
         assert args[0].id == user_dict['id']
         assert args[0].email == user_dict['email']
-        assert args[1] == 'Your CKAN password has changed'
+        assert args[1] == 'Your data.gov.uk publisher password has changed'
         assert args[2] == "Your password has been changed, if you haven't done it yourself, let us know"

--- a/ckanext/datagovuk/tests/test_ckan_patches.py
+++ b/ckanext/datagovuk/tests/test_ckan_patches.py
@@ -41,7 +41,6 @@ class TestSetPass(DBTest):
     def setup(self):
         helpers.reset_db()
 
-
     @patch('ckan.lib.cli.UserCmd.password_prompt', return_value='newpassword')
     @patch('ckanext.datagovuk.lib.mailer.mailer.mail_user')
     def test_setpass_sends_email_alert_to_user(self, mock_mailer, mock_password_prompt):

--- a/ckanext/datagovuk/tests/test_ckan_patches.py
+++ b/ckanext/datagovuk/tests/test_ckan_patches.py
@@ -1,5 +1,9 @@
 """Tests for DGU monkey patches of CKAN."""
+from mock import patch
+
 from ckan import model
+import ckan.lib.cli
+from ckan.tests.lib.test_cli import paster
 from ckan.tests import factories, helpers
 from ckanext.datagovuk.tests.db_test import DBTest
 
@@ -31,3 +35,26 @@ class TestLogin(DBTest):
 
         user = model.User.get(user_dict['id'])
         self.assertTrue(user.validate_password('pass'))
+
+
+class TestSetPass(DBTest):
+    def setup(self):
+        helpers.reset_db()
+
+
+    @patch('ckan.lib.cli.UserCmd.password_prompt', return_value='newpassword')
+    @patch('ckanext.datagovuk.lib.mailer.mailer.mail_user')
+    def test_setpass_sends_email_alert_to_user(self, mock_mailer, mock_password_prompt):
+        user_dict = factories.User(password='hello123')
+
+        user_cmd = ckan.lib.cli.UserCmd('test')
+        user_cmd.args =['setpass', user_dict['name']]
+
+        user_cmd.setpass()
+
+        assert mock_mailer.called
+        args, kwargs = mock_mailer.call_args
+        assert args[0].id == user_dict['id']
+        assert args[0].email == user_dict['email']
+        assert args[1] == 'Your CKAN password has changed'
+        assert args[2] == "Your password has been changed, if you haven't done it yourself, let us know"


### PR DESCRIPTION
## What

Send an email to the user whenever their password changes, either from the GUI, from a reset link or from the CLI.

## Why

There was an incident when the password was reset but no one knew how, this should add additional logs for when password get changed so that we have more visibility if someone attempts to gain unauthorised access.

## Reference

https://trello.com/c/EQcYxINw/1755-5-implement-email-alerts-to-users-when-their-password-is-changed-in-ckan