### PR TITLE
Form upgrades

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -59,14 +59,6 @@ a.btn .icon-briefcase {
   background-position: 36px 17px;
 }
 
-.form-horizontal .control-label {
-  width: 140px;
-}
-
-.form-horizontal .controls {
-  margin-left: 145px;
-}
-
 .controls #field-schema-vocabulary,
 .controls #field-codelist {
   width: 100%;
@@ -114,4 +106,92 @@ p.home-footer-text {
   .toolbar .breadcrumb a {
     color: #505050;
   }
+}
+
+.form-control {
+  margin-bottom: 14px;
+}
+
+.control-label {
+  text-align: right;
+  padding-right: 0;
+  padding-top: 4px;
+}
+
+.control-full input[type=radio]{
+  width: auto;
+}
+
+.harvest-types label.radio {
+  margin-bottom: 0;
+}
+
+.harvest-types label.radio input{
+  top: -1px;
+}
+
+.editor-info-block {
+  margin-top: -14px;
+  margin-bottom: 14px;
+}
+
+.float-container,
+.form-group {
+  overflow: auto;
+}
+
+.form-group {
+  margin-bottom: 14px;
+}
+
+.form-control {
+  height: 32px;
+}
+
+.select2-container.form-control {
+  padding: 0;
+  border: 0;
+}
+
+.select2-drop {
+  margin-top: -7px;
+}
+
+.select2-drop.select2-drop-above {
+  margin-top: -3px;
+}
+
+.form-actions {
+  padding-top: 14px;
+  border-top: 1px solid #707070;
+}
+
+.btn-danger {
+  background-image: linear-gradient(to bottom,#ee5f5b,#bd362f);
+}
+
+.btn-primary {
+  background-image: linear-gradient(to bottom,#30778d,#085871);
+}
+
+.js .image-upload .btn-remove-url {
+  margin-right: 15px;
+}
+
+.error .input-group-addon {
+  float: left;
+  display: block;
+  width: auto;
+}
+
+.error-block {
+  margin-top: -2px;
+}
+
+.error .form-control {
+  margin-bottom: -4px;
+}
+
+.u-overflow-hidden {
+  overflow: hidden;
 }

--- a/ckanext/datagovuk/templates/macros/form.html
+++ b/ckanext/datagovuk/templates/macros/form.html
@@ -1,0 +1,447 @@
+{#
+Creates all the markup required for an input element. Handles matching labels to
+inputs, error messages and other useful elements.
+
+name        - The name of the form parameter.
+id          - The id to use on the input and label. Convention is to prefix with 'field-'.
+label       - The human readable label.
+value       - The value of the input.
+placeholder - Some placeholder text.
+type        - The type of input eg. email, url, date (default: text).
+error       - A list of error strings for the field or just true to highlight the field.
+classes     - An array of classes to apply to the form-group.
+is_required - Boolean of whether this input is requred for the form to validate
+
+Examples:
+
+{% import 'macros/form.html' as form %}
+{{ form.input('title', label=_('Title'), value=data.title, error=errors.title) }}
+
+#}
+{% macro input(name, id='', label='', value='', placeholder='', type='text', error="", classes=[], attrs={'class': 'form-control'}, is_required=false, input_classes=[], label_classes=[]) %}
+{%- set extra_html = caller() if caller -%}
+
+{% call input_block(id or name, label or name, error, classes, extra_html=extra_html, is_required=is_required) %}
+<input id="{{ id or name }}" type="{{ type }}" name="{{ name }}" class="form-control" value="{{ value | empty_and_escape }}" placeholder="{{ placeholder }}" {{ attributes(attrs) }} />
+{% endcall %}
+{% endmacro %}
+
+{#
+Builds a single checkbox input.
+
+name        - The name of the form parameter.
+id          - The id to use on the input and label. Convention is to prefix with 'field-'.
+label       - The human readable label.
+value       - The value of the input.
+checked     - If true the checkbox will be checked
+error       - An error string for the field or just true to highlight the field.
+classes     - An array of classes to apply to the form-group.
+is_required - Boolean of whether this input is requred for the form to validate
+
+Example:
+
+{% import 'macros/form.html' as form %}
+{{ form.checkbox('remember', checked=true) }}
+
+#}
+{% macro checkbox(name, id='', label='', value='', checked=false, placeholder='', error="", classes=[], attrs={}, is_required=false) %}
+{%- set extra_html = caller() if caller -%}
+<div class="form-group{{ " " ~ classes | join(" ") }}{% if error %} error{% endif %}">
+<div class="controls">
+  <label class="checkbox" for="{{ id or name }}">
+    <input id="{{ id or name }}" type="checkbox" name="{{ name }}" value="{{ value | empty_and_escape }}" {{ "checked " if checked }} {{ attributes(attrs) }} />
+    {{ label or name }}
+    {% if is_required %}{{ input_required() }}{% endif %}
+    {% if error and error is iterable %}<strong class="error-inline">{{ error|join(', ') }}</strong>{% endif %}
+  </label>
+  {{ extra_html }}
+</div>
+</div>
+{% endmacro %}
+
+{#
+Creates all the markup required for an select element. Handles matching labels to
+inputs and error messages.
+
+A field should be a dict with a "value" key and an optional "text" key which
+will be displayed to the user. We use a dict to easily allow extension in
+future should extra options be required.
+
+name        - The name of the form parameter.
+id          - The id to use on the input and label. Convention is to prefix with 'field-'.
+label       - The human readable label.
+options     - A list/tuple of fields to be used as <options>.
+  selected    - The value of the selected <option>.
+    error       - A list of error strings for the field or just true to highlight the field.
+    classes     - An array of classes to apply to the form-group.
+    is_required - Boolean of whether this input is requred for the form to validate
+
+    Examples:
+
+    {% import 'macros/form.html' as form %}
+    {{ form.select('year', label=_('Year'), options=[{'name':2010, 'value': 2010},{'name': 2011, 'value': 2011}], selected=2011, error=errors.year) }}
+
+    #}
+    {% macro select(name, id='', label='', options='', selected='', error='', classes=[], attrs={'class': 'form-control'}, is_required=false) %}
+    {% set classes = (classes|list) %}
+    {% do classes.append('control-select') %}
+
+    {%- set extra_html = caller() if caller -%}
+    {% call input_block(id or name, label or name, error, classes, extra_html=extra_html, is_required=is_required) %}
+    <select id="{{ id or name }}" name="{{ name }}" {{ attributes(attrs) }}>
+      {% for option in options %}
+  <option value="{{ option.value }}"{% if option.value == selected %} selected{% endif %}>{{ option.text or option.value }}</option>
+  {% endfor %}
+  </select>
+  {% endcall %}
+  {% endmacro %}
+
+  {#
+  Creates all the markup required for a Markdown textarea element. Handles
+  matching labels to inputs, selected item and error messages.
+
+  name        - The name of the form parameter.
+  id          - The id to use on the input and label. Convention is to prefix with 'field-'.
+  label       - The human readable label.
+  value       - The value of the input.
+  placeholder - Some placeholder text.
+  error       - A list of error strings for the field or just true to highlight the field.
+  classes     - An array of classes to apply to the form-group.
+  is_required - Boolean of whether this input is requred for the form to validate
+
+  Examples:
+
+  {% import 'macros/form.html' as form %}
+  {{ form.markdown('desc', id='field-description', label=_('Description'), value=data.desc, error=errors.desc) }}
+
+  #}
+  {% macro markdown(name, id='', label='', value='', placeholder='', error="", classes=[], attrs={'class': 'form-control'}, is_required=false) %}
+  {% set classes = (classes|list) %}
+  {% do classes.append('control-full') %}
+  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='text-muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %}
+
+  {%- set extra_html = caller() if caller -%}
+  {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}
+  <textarea id="{{ id or name }}" name="{{ name }}" class="form-control" cols="20" rows="5" placeholder="{{ placeholder }}" {{ attributes(attrs) }}>{{ value | empty_and_escape }}</textarea>
+  <span class="editor-info-block">{% trans %}You can use <a href="#markdown" title="Markdown quick reference" data-target="popover" data-content="{{ markdown_tooltip }}" data-html="true">Markdown formatting</a> here{% endtrans %}</span>
+  {% endcall %}
+  {% endmacro %}
+
+  {#
+  Creates all the markup required for a plain textarea element. Handles
+  matching labels to inputs, selected item and error messages.
+
+  name        - The name of the form parameter.
+  id          - The id to use on the input and label. Convention is to prefix with 'field-'.
+  label       - The human readable label.
+  value       - The value of the input.
+  placeholder - Some placeholder text.
+  error       - A list of error strings for the field or just true to highlight the field.
+  classes     - An array of classes to apply to the form-group.
+  is_required - Boolean of whether this input is requred for the form to validate
+
+  Examples:
+
+  {% import 'macros/form.html' as form %}
+  {{ form.textarea('desc', id='field-description', label=_('Description'), value=data.desc, error=errors.desc) }}
+
+  #}
+  {% macro textarea(name, id='', label='', value='', placeholder='', error="", classes=[], attrs={'class': 'form-control'}, is_required=false, rows=5, cols=20) %}
+  {% set classes = (classes|list) %}
+  {% do classes.append('control-full') %}
+
+  {%- set extra_html = caller() if caller -%}
+  {% call input_block(id or name, label or name, error, classes, extra_html=extra_html, is_required=is_required) %}
+  <textarea id="{{ id or name }}" name="{{ name }}" cols="{{ cols }}" rows="{{ rows }}" placeholder="{{ placeholder }}" {{ attributes(attrs) }}>{{ value | empty_and_escape }}</textarea>
+  {% endcall %}
+  {% endmacro %}
+
+  {#
+  Creates all the markup required for an input element with a prefixed segment.
+  These are useful for showing url slugs and other fields where the input
+  information forms only part of the saved data.
+
+  name        - The name of the form parameter.
+  id          - The id to use on the input and label. Convention is to prefix with 'field-'.
+  label       - The human readable label.
+  prepend     - The text that will be prepended before the input.
+  value       - The value of the input.
+  which will use the name key as the value.
+  placeholder - Some placeholder text.
+  error       - A list of error strings for the field  or just true to highlight the field.
+  classes     - An array of classes to apply to the form-group.
+  is_required - Boolean of whether this input is requred for the form to validate
+
+  Examples:
+
+  {% import 'macros/form.html' as form %}
+  {{ form.prepend('slug', id='field-slug', prepend='/dataset/', label=_('Slug'), value=data.slug, error=errors.slug) }}
+
+  #}
+  {% macro prepend(name, id='', label='', prepend='', value='', placeholder='', type='text', error="", classes=[], attrs={'class': 'form-control'}, is_required=false) %}
+  {# We manually append the error here as it needs to be inside the .input-group block #}
+  {% set classes = (classes|list) %}
+  {% do classes.append('error') if error %}
+  {%- set extra_html = caller() if caller -%}
+  {% call input_block(id or name, label or name, error='', classes=classes, extra_html=extra_html, is_required=is_required) %}
+  <div class="input-group">
+    {% if prepend %}<span class="input-group-addon">{{ prepend }}</span>{%- endif -%}
+    <input id="{{ id or name }}" type="{{ type }}" name="{{ name }}" value="{{ value | empty_and_escape }}" placeholder="{{ placeholder }}" {{ attributes(attrs) }} />
+    {% if error and error is iterable %}<span class="error-block">{{ error|join(', ') }}</span>{% endif %}
+  </div>
+  {% endcall %}
+  {% endmacro %}
+
+  {#
+  Creates all the markup required for an custom key/value input. These are usually
+  used to let the user provide custom meta data. Each "field" has three inputs
+  one for the key, one for the value and a checkbox to remove it. So the arguments
+  for this macro are nearly all tuples containing values for the
+  (key, value, delete) fields respectively.
+
+  name        - A tuple of names for the three fields.
+  id          - An id string to be used for each input.
+  label       - The human readable label for the main label.
+  values      - A tuple of values for the (key, value, delete) fields. If delete
+  is truthy the checkbox will be checked.
+  placeholder - A tuple of placeholder text for the (key, value) fields.
+  error       - A list of error strings for the field or just true to highlight the field.
+  classes     - An array of classes to apply to the form-group.
+  is_required - Boolean of whether this input is requred for the form to validate
+
+  Examples:
+
+  {% import 'macros/form.html' as form %}
+  {{ form.custom(
+  names=('custom_key', 'custom_value', 'custom_deleted'),
+  id='field-custom',
+  label=_('Custom Field'),
+  values=(extra.key, extra.value, extra.deleted),
+  error=''
+  ) }}
+  #}
+  {% macro custom(names=(), id="", label="", values=(), placeholders=(), error="", classes=[], attrs={}, is_required=false, key_values=()) %}
+  {%- set classes = (classes|list) -%}
+  {%- set label_id = (id or names[0]) ~ "-key" -%}
+  {%- set extra_html = caller() if caller -%}
+  {%- do classes.append('control-custom') -%}
+
+  {% call input_block(label_id, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}
+  <div class="row">
+    <div class="col-md-6">
+      <div class="input-group" {{ attributes(attrs) }}>
+        <label for="{{ label_id }}" class="input-group-addon">{{ _('Key') }}</label>
+        <input class="form-control" id="{{ id or names[0] }}-key" type="text" name="{{ names[0] }}" value="{{ values[0] | empty_and_escape }}" placeholder="{{ placeholders[0] }}" />
+      </div>
+    </div>
+    <div class="col-md-6">
+      {% if values[0] or values[1] or error %}
+      <label class="checkbox pull-right" for="{{ id or names[2] }}-remove">
+        <input type="checkbox" id="{{ id or names[2] }}-remove" name="{{ names[2] }}"{% if values[2] %} checked{% endif %} />
+        <span class="btn btn-danger"><span class="fa fa-trash"></span><span class="sr-only">{{ _('Remove') }}</span></span>
+      </label>
+      {% endif %}
+      <div class="input-group" {{ attributes(attrs) }}>
+        <label for="{{ id or names[1] }}-value" class="input-group-addon">{{ _('Value') }}</label>
+        <input class="form-control" id="{{ id or names[1] }}-value" type="text" name="{{ names[1] }}" value="{{ values[1] | empty_and_escape }}" placeholder="{{ placeholders[1] }}" />
+      </div>
+    </div>
+  </div>
+
+  {% endcall %}
+  {% endmacro %}
+
+  {#
+  A generic input_block for providing the default markup for CKAN form elements.
+  It is expected to be called using a {% call %} block, the contents of which
+  will be inserted into the .controls element.
+
+  for     - The id for the input that the label should match.
+  label   - A human readable label.
+  error   - A list of error strings for the field or just true.
+  classes - An array of custom classes for the outer element.
+  control_classes - An array of custom classes for the .control wrapper.
+  extra_html - An html string to be inserted after the errors eg. info text.
+  is_required - Boolean of whether this input is requred for the form to validate
+
+  Example:
+
+  {% import 'macros/form.html' as form %}
+  {% call form.input_block("field", "My Field") %}
+  <input id="field" type="text" name="{{ name }}" value="{{ value | empty_and_escape }}" />
+  {% endcall %}
+
+  {% call input_block(id or name, label or name, error, classes, extra_html=extra_html, is_required=is_required) %}
+
+
+  #}
+  {% macro input_block(for, label="", error="", classes=[], control_classes=[], extra_html="", is_required=false) %}
+  <div class="form-group{{ " error" if error }}{{ " " ~ classes | join(' ') }}">
+  <label class="control-label col-md-3" for="{{ for }}">{% if is_required %}<span title="{{ _("This field is required") }}" class="control-required">*</span> {% endif %}{{ label or _('Custom') }}</label>
+  <div class="col-md-9 controls{{ " " ~ control_classes | join(' ') }}">
+  {{ caller() }}
+  {% if error and error is iterable %}<span class="error-block">{{ error|join(', ') }}</span>{% endif %}
+  {{ extra_html }}
+  </div>
+  </div>
+  {% endmacro %}
+
+  {#
+  Builds a list of errors for the current form.
+
+  errors  - A dict of field/message pairs.
+  type    - The alert-* class that should be applied (default: "error")
+  classes - A list of classes to apply to the wrapper (default: [])
+
+  Example:
+
+  {% import 'macros/form.html' as form %}
+  {{ form.errors(error_summary, type="warning") }}
+
+  #}
+  {% macro errors(errors={}, type="error", classes=[]) %}
+  {% if errors %}
+  <div class="error-explanation alert alert-{{ type }}{{ " " ~ classes | join(' ') }}">
+  <p>{{ _('The form contains invalid entries:') }}</p>
+  <ul>
+    {% for key, error in errors.items() %}
+    <li data-field-label="{{ key }}">{% if key %}{{ key }}: {% endif %}{{ error }}</li>
+    {% endfor %}
+  </ul>
+  </div>
+  {% endif %}
+  {% endmacro %}
+
+  {#
+  Renders an info box with a description. This will usually be used with in a
+  call block when creating an input element.
+
+  text    - The text to include in the box.
+  inline  - If true displays the info box inline with the input.
+  classes - A list of classes to add to the info box.
+
+  Example
+
+  {% import 'macros/form.html' as form %}
+  {% call form.input('name') %}
+  {{ form.info(_('My useful help text')) }}
+  {% endcall %}
+
+  #}
+  {% macro info(text='', inline=false, classes=[]) %}
+  {%- if text -%}
+  <div class="info-block{{ ' info-inline' if inline }}{{ " " ~ classes | join(' ') }}">
+  <i class="fa fa-info-circle"></i>
+  {{ text }}
+  </div>
+  {%- endif -%}
+  {% endmacro %}
+
+  {#
+  Builds a single hidden input.
+
+  name  - name of the hidden input
+  value - value of the hidden input
+
+  Example
+  {% import 'macros/form.html' as form %}
+  {{ form.hidden('name', 'value') }}
+
+  #}
+  {% macro hidden(name, value) %}
+  <input type="hidden" name="{{ name }}" value="{{ value }}" />
+  {% endmacro %}
+
+  {#
+  Contructs hidden inputs for each name-value pair.
+
+  fields - [('name1', 'value1'), ('name2', 'value2'), ...]
+
+  Two parameter for excluding several names or name-value pairs.
+
+  except_names - list of names to be excluded
+  except       - list of name-value pairs to be excluded
+
+
+  Example:
+  {% import 'macros/form.html' as form %}
+  {% form.hidden_from_list(fields=c.fields, except=[('topic', 'xyz')]) %}
+  {% form.hidden_from_list(fields=c.fields, except_names=['time_min', 'time_max']) %}
+  #}
+  {% macro hidden_from_list(fields, except_names=None, except=None) %}
+  {% set except_names = except_names or [] %}
+  {% set except = except or [] %}
+
+  {% for name, value in fields %}
+  {% if name and value and name not in except_names and (name, value) not in except %}
+  {{ hidden(name, value) }}
+  {% endif %}
+  {% endfor %}
+  {% endmacro %}
+
+  {#
+  Builds a space seperated list of html attributes from a dict of key/value pairs.
+  Generally only used internally by macros.
+
+  attrs - A dict of attribute/value pairs
+
+  Example
+
+  {% import 'macros/form.html' as form %}
+  {{ form.attributes({}) }}
+
+  #}
+  {%- macro attributes(attrs={}) -%}
+  {%- for key, value in attrs.items() -%}
+  {{ " " }}{{ key }}{% if value != "" %}="{{ value }}"{% endif %}
+  {%- endfor -%}
+  {%- endmacro -%}
+
+  {#
+  Outputs the "* Required field" message for the bottom of formss
+
+  Example
+  {% import 'macros/form.html' as form %}
+  {{ form.required_message() }}
+
+  #}
+  {% macro required_message() %}
+  <p class="control-required-message">
+    <span class="control-required">*</span> {{ _("Required field") }}
+  </p>
+  {% endmacro %}
+
+  {#
+  Builds a file upload for input
+
+  Example
+  {% import 'macros/form.html' as form %}
+  {{ form.image_upload(data, errors, is_upload_enabled=true) }}
+
+  #}
+{% macro image_upload(data, errors, field_url='image_url', field_upload='image_upload', field_clear='clear_upload',
+                      is_url=false, is_upload=false, is_upload_enabled=false, placeholder=false,
+                      url_label='', upload_label='', field_name='image_url')  %}
+  {% set placeholder = placeholder if placeholder else _('http://example.com/my-image.jpg') %}
+  {% set url_label = url_label or _('Image URL')  %}
+  {% set upload_label = upload_label or _('Image')  %}
+
+  {% if is_upload_enabled %}
+  <div class="image-upload" data-module="image-upload" data-module-is_url="{{ 'true' if is_url else 'false' }}" data-module-is_upload="{{ 'true' if is_upload else 'false' }}"
+       data-module-field_url="{{ field_url }}" data-module-field_upload="{{ field_upload }}" data-module-field_clear="{{ field_clear }}" data-module-upload_label="{{ upload_label }}" data-module-field_name="{{ field_name }}">
+  {% endif %}
+
+
+   {{ input(field_url, label=url_label, id='field-image-url', type='url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=['control-full']) }}
+
+
+    {% if is_upload_enabled %}
+    {{ input(field_upload, label=upload_label, id='field-image-upload', type='file', placeholder='', value='', error='', classes=['control-full', 'u-overflow-hidden']) }}
+    {% if is_upload %}
+    {{ checkbox(field_clear, label=_('Clear Upload'), id='field-clear-upload', value='true', error='', classes=['control-full']) }}
+    {% endif %}
+    {% endif %}
+
+    {% if is_upload_enabled %}</div>{% endif %}
+
+  {% endmacro %}

--- a/ckanext/datagovuk/templates/organization/snippets/organization_form.html
+++ b/ckanext/datagovuk/templates/organization/snippets/organization_form.html
@@ -24,7 +24,7 @@
 
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my organization...'), value=data.description, error=errors.description) }}
 
-    {{ form.select('category', label=_('Category'), options=h.publisher_category(), selected=data.get('category', ''), error=errors.category, attrs=attrs) }}
+    {{ form.select('category', label=_('Category'), options=h.publisher_category(), selected=data.get('category', ''), error=errors.category, attrs={'class': 'form-control'}) }}
 
     {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
     {% set is_url = data.image_url and data.image_url.startswith('http') %}

--- a/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_metadata_fields.html
@@ -11,10 +11,10 @@
 
 {% block custom_fields %}
 {# This block appears at the bottom of the form, in place of the custom fields in default CKAN #}
-<div class="control-group">
-  <label class="control-label" for="theme-primary">{{ _("Theme") }}</label>
-  <div class="controls">
-    <select id="field-theme-primary" name="theme-primary">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="theme-primary">{{ _("Theme") }}</label>
+  <div class="controls col-md-4">
+    <select id="field-theme-primary" class="form-control" name="theme-primary">
       <option value></option>
       {% for theme in h.alphabetise_dict(h.themes()) %}
         <option value="{{ theme[0] }}" {% if data.get('theme-primary', '') == theme[0] %}selected="selected"{% endif %}>{{ theme[1] }}</option>
@@ -27,10 +27,10 @@
     {% endif %}
   </div>
 </div>
-<div class="control-group">
-  <label class="control-label" for="schema-vocabulary">{{ _("Schema/Vocabulary") }}</label>
-  <div class="controls">
-    <select id="field-schema-vocabulary" name="schema-vocabulary">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="schema-vocabulary">{{ _("Schema/Vocabulary") }}</label>
+  <div class="controls col-md-9">
+    <select id="field-schema-vocabulary" class="form-control" name="schema-vocabulary">
       <option value></option>
       {% for schema in h.alphabetise_dict(h.schemas()) %}
         <option value="{{ schema[0] }}" {% if data.get('schema-vocabulary', '') == schema[0] %}selected="selected"{% endif %}>{{ schema[1].decode("utf8") }}</option>
@@ -43,10 +43,10 @@
     {% endif %}
   </div>
 </div>
-<div class="control-group">
-  <label class="control-label" for="codelist">{{ _("Code Lists") }}</label>
-  <div class="controls">
-    <select id="field-codelist" name="codelist">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="codelist">{{ _("Code Lists") }}</label>
+  <div class="controls col-md-9">
+    <select id="field-codelist" name="codelist" class="form-control">
       <option value></option>
       {% for codelist in h.alphabetise_dict(h.codelist()) %}
         <option value="{{ codelist[0] }}" {% if data.get('codelist', '') == codelist[0] %}selected="selected"{% endif %}>{{ codelist[1] }}</option>
@@ -59,52 +59,52 @@
     {% endif %}
   </div>
 </div>
-<div class="control-group">
-  {{ _("By default, the contact details for your organisation will be displayed alongside this dataset.  You can override them for only this dataset by specifying them here.") }}
+<div class="form-group control-group">
+  <p>{{ _("By default, the contact details for your organisation will be displayed alongside this dataset.  You can override them for only this dataset by specifying them here.") }}</p>
 </div>
-<div class="control-group">
-  <label class="control-label" for="contact-name">{{ _("Contact Name") }}</label>
-  <div class="controls">
-    <input type="text" id="field-contact-name" name="contact-name" value="{{ data.get('contact-name','') }}">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="contact-name">{{ _("Contact Name") }}</label>
+  <div class="controls col-md-4">
+    <input type="text" id="field-contact-name" name="contact-name" class="form-control" value="{{ data.get('contact-name','') }}">
   </div>
 </div>
-<div class="control-group">
-  <label class="control-label" for="contact-email">{{ _("Contact Email") }}</label>
-  <div class="controls">
-    <input type="text" id="field-contact-email" name="contact-email" value="{{ data.get('contact-email','') }}">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="contact-email">{{ _("Contact Email") }}</label>
+  <div class="controls col-md-4">
+    <input type="text" id="field-contact-email" name="contact-email" class="form-control" value="{{ data.get('contact-email','') }}">
   </div>
 </div>
-<div class="control-group">
-  <label class="control-label" for="contact-phone">{{ _("Contact Phone") }}</label>
-  <div class="controls">
-    <input type="text" id="field-contact-phone" name="contact-phone" value="{{ data.get('contact-phone','') }}">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="contact-phone">{{ _("Contact Phone") }}</label>
+  <div class="controls col-md-4">
+    <input type="text" id="field-contact-phone" name="contact-phone" class="form-control" value="{{ data.get('contact-phone','') }}">
   </div>
 </div>
-<div class="control-group">
-  <label class="control-label" for="foi-name">{{ _("FOI Name") }}</label>
-  <div class="controls">
-    <input type="text" id="field-foi-name" name="foi-name" value="{{ data.get('foi-name','') }}">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="foi-name">{{ _("FOI Name") }}</label>
+  <div class="controls col-md-4">
+    <input type="text" id="field-foi-name" class="form-control" name="foi-name" value="{{ data.get('foi-name','') }}">
   </div>
 </div>
-<div class="control-group">
-  <label class="control-label" for="foi-email">{{ _("FOI Email") }}</label>
-  <div class="controls">
-    <input type="text" id="field-foi-email" name="foi-email" value="{{ data.get('foi-email','') }}">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="foi-email">{{ _("FOI Email") }}</label>
+  <div class="controls col-md-4">
+    <input type="text" id="field-foi-email" class="form-control" name="foi-email" value="{{ data.get('foi-email','') }}">
   </div>
 </div>
-<div class="control-group">
-  <label class="control-label" for="foi-web">{{ _("FOI Web") }}</label>
-  <div class="controls">
-    <input type="text" id="field-foi-web" name="foi-web" value="{{ data.get('foi-web','') }}">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="foi-web">{{ _("FOI Web") }}</label>
+  <div class="controls col-md-4">
+    <input type="text" id="field-foi-web" class="form-control" name="foi-web" value="{{ data.get('foi-web','') }}">
   </div>
 </div>
-<div class="control-group">
-  <label class="control-label" for="foi-phone">{{ _("FOI Phone") }}</label>
-  <div class="controls">
-    <input type="text" id="field-foi-phone" name="foi-phone" value="{{ data.get('foi-phone','') }}">
+<div class="form-group control-group">
+  <label class="control-label col-md-3" for="foi-phone">{{ _("FOI Phone") }}</label>
+  <div class="controls col-md-4">
+    <input type="text" id="field-foi-phone" class="form-control" name="foi-phone" value="{{ data.get('foi-phone','') }}">
   </div>
 </div>
-<div class="control-group">
+<div class="form-group control-group">
   {{ _("Metadata fields from datasets will be publicly available to users - including (where provided to us) personal information such as contact details for responsible parties.") }}
 </div>
 {% endblock %}

--- a/ckanext/datagovuk/templates/snippets/package_basic_fields.html
+++ b/ckanext/datagovuk/templates/snippets/package_basic_fields.html
@@ -1,56 +1,58 @@
 {% ckan_extends %}
 {% import 'macros/form.html' as form %}
 
-{% block package_basic_fields_custom %}
-{# This block is located between the Title and Description in the default CKAN templates #}
-{% endblock %}
-
 {% block package_basic_fields_title %}
-  {{ form.input('title', id='field-title', label=_('Title'), value=data.title, error=errors.title, classes=['control-full', 'control-large'], attrs={'data-module': 'slug-preview-target'}) }}
+{{ form.input('title', id='field-title', label=_('Title'), placeholder=_('eg. A descriptive title'), value=data.title, error=errors.title, classes=['control-full', 'control-large'], attrs={'data-module': 'slug-preview-target', 'class': 'form-control'}) }}
 {% endblock %}
 
 {% block package_basic_fields_url %}
-  {% set prefix = h.url_for(controller='package', action='read', id='') %}
-  {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': '/', 'data-module-placeholder': '<dataset>'} %}
+{% set prefix = h.url_for(controller='package', action='read', id='') %}
+{% set domain = h.url_for(controller='package', action='read', id='', qualified=true) %}
+{% set domain = domain|replace("http://", "")|replace("https://", "") %}
+{% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<dataset>', 'class': 'form-control input-sm'} %}
+
   {{ form.prepend('name', id='field-name', label=_('URL'), prepend=prefix, placeholder=_('eg. my-dataset'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
-{% endblock %}
+  {% endblock %}
 
-{% block package_basic_fields_description %}
+  {% block package_basic_fields_custom %}{% endblock %}
+
+  {% block package_basic_fields_description %}
   {{ form.markdown('notes', id='field-notes', label=_('Description'), placeholder=_('eg. Some useful notes about the data'), value=data.notes, error=errors.notes) }}
-{% endblock %}
+  {% endblock %}
 
-{% block package_basic_fields_license %}
-<div class="form-group">
-  {% set error = errors.license_id %}
-  <div class="controls">
-    <label class="control-label col-md-3" for="field-license">{{ _("License") }}</label>
-    <div class="col-md-4">
-      <select id="field-license" name="license_id" data-module="autocomplete">
-        {% set existing_license_id = data.get('license_id') %}
-        {% for license_id, license_desc in h.license_options(existing_license_id) %}
-        <option value="{{ license_id }}" {% if existing_license_id == license_id %}selected="selected"{% endif %}>{{ license_desc }}</option>
-        {% endfor %}
-      </select>
-      {% if error %}<span class="error-block">{{ error }}</span>{% endif %}
-    </div>
-    <div class="col-md-5">
-      <span class="info-block info-inline">
-        <i class="fa fa-info-circle"></i>
-        {% trans %}
-        License definitions and additional information can be found
-        at <a href="http://opendefinition.org/licenses/">opendefinition.org</a>
-        {% endtrans %}
-      </span>
+  {% block package_basic_fields_tags %}
+  {% set tag_attrs = {'data-module': 'autocomplete', 'data-module-tags': '', 'data-module-source': '/api/2/util/tag/autocomplete?incomplete=?'} %}
+  {{ form.input('tag_string', id='field-tags', label=_('Tags'), placeholder=_('eg. economy, mental health, government'), value=data.tag_string, error=errors.tags, classes=['control-full'], attrs=tag_attrs) }}
+  {% endblock %}
+
+  {% block package_basic_fields_license %}
+  <div class="form-group">
+    {% set error = errors.license_id %}
+    <label class="control-label" for="field-license">{{ _("License") }}</label>
+    <div class="controls">
+      <div class="row">
+        <div class="col-md-6">
+          <select id="field-license" name="license_id" data-module="autocomplete">
+            {% set existing_license_id = data.get('license_id') %}
+            {% for license_id, license_desc in h.license_options(existing_license_id) %}
+            <option value="{{ license_id }}" {% if existing_license_id == license_id %}selected="selected"{% endif %}>{{ license_desc }}</option>
+            {% endfor %}
+          </select>
+          {% if error %}<span class="error-block">{{ error }}</span>{% endif %}
+        </div>
+        <div class="col-md-6">
+          <span class="info-block info-inline">
+            <i class="fa fa-info-circle"></i>
+            {% trans %}
+            License definitions and additional information can be found
+            at <a href="http://opendefinition.org/licenses/">opendefinition.org</a>
+            {% endtrans %}
+          </span>
+        </div>
+      </div>
     </div>
   </div>
-</div>
-<div class="control-group form-group">
-  <label class="control-label col-md-3" for="licence-custom">{{ _("Licence Information") }}</label>
-  <div class="controls col-md-4">
-    <input type="text" class="form-control" id="field-licence-custom" name="licence-custom" value="{{ data.get('licence-custom','') }}">
-  </div>
-</div>
-{% endblock %}
+  {% endblock %}
 
   {% block package_basic_fields_org %}
   {# if we have a default group then this wants remembering #}
@@ -72,9 +74,9 @@
     {% if show_organizations_selector %}
     {% set existing_org = data.owner_org or data.group_id %}
     <div class="form-group control-medium">
-      <label for="field-organizations" class="control-label col-md-3">{{ _('Organization') }}</label>
-      <div class="controls col-md-4">
-        <select id="field-organizations"name="owner_org" data-module="autocomplete">
+      <label for="field-organizations" class="control-label">{{ _('Organization') }}</label>
+      <div class="controls">
+        <select id="field-organizations" name="owner_org" data-module="autocomplete">
           {% if h.check_config_permission('create_unowned_dataset') %}
           <option value="" {% if not selected_org and data.id %} selected="selected" {% endif %}>{{ _('No organization') }}</option>
           {% endif %}
@@ -90,7 +92,16 @@
 
     {% if show_visibility_selector %}
     {% block package_metadata_fields_visibility %}
-      <input type="hidden" name="private" value="False">
+    <div class="form-group control-medium">
+      <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
+      <div class="controls">
+        <select id="field-private" name="private" class="form-control">
+          {% for option in [('True', _('Private')), ('False', _('Public'))] %}
+          <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
     {% endblock %}
     {% endif %}
 
@@ -112,10 +123,3 @@
   {% endif %}
 
   {% endblock %}
-
-
-
-{% block package_basic_fields_tags %}
-{% endblock %}
-
-

--- a/ckanext/datagovuk/templates/snippets/search_form.html
+++ b/ckanext/datagovuk/templates/snippets/search_form.html
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+
+{% block search_input %}
+  <div class="input-group search-input-group control-large">
+    <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
+    {% block search_input_button %}
+    <span class="input-group-btn">
+      <button class="btn btn-default btn-lg" type="submit" value="search">
+        <i class="fa fa-search"></i>
+      </button>
+    </span>
+    {% endblock %}
+  </div>
+{% endblock %}

--- a/ckanext/datagovuk/templates/source/new_source_form.html
+++ b/ckanext/datagovuk/templates/source/new_source_form.html
@@ -22,9 +22,9 @@
 
   {{ form.markdown('notes', id='field-notes', label=_('Description'), value=data.notes, error=errors.notes) }}
 
-  <div class="harvest-types control-group">
-    <label class="control-label">Source type</label>
-    <div class="controls">
+  <div class="form-group harvest-types control-group control-full">
+    <label class="control-label col-md-3">Source type</label>
+    <div class="controls col-md-9">
       {% for harvester in h.harvesters_info() %}
         {% set checked = False %}
         {# select first option if nothing in data #}
@@ -59,9 +59,9 @@
 
   {% if show_organizations_selector %}
     {% set existing_org = data.owner_org %}
-    <div class="control-group">
-      <label for="field-organizations" class="control-label">{{ _('Organization') }}</label>
-      <div class="controls">
+    <div class="form-group control-group">
+      <label for="field-organizations" class="control-label col-md-3">{{ _('Organization') }}</label>
+      <div class="controls col-md-9">
         <select id="field-organizations" name="owner_org" data-module="autocomplete">
           <option value="" {% if not selected_org and data.id %} selected="selected" {% endif %}>{{ _('No organization') }}</option>
           {% for organization in organizations_available %}
@@ -74,15 +74,15 @@
     </div>
   {% endif %}
 
-  <div class="control-group">
-    {{ _("Metadata fields from harvested datasets will be publicly available to users - including (where provided to us) personal information such as contact details for responsible parties.") }}
+  <div class="form-group control-group">
+    <p>{{ _("Metadata fields from harvested datasets will be publicly available to users - including (where provided to us) personal information such as contact details for responsible parties.") }}</p>
   </div>
 
   {% if data.get('id', None) and h.check_access('harvest_source_delete', {'id': data.id}) and data.get('state', 'none') == 'deleted' %}
-    <div class="control-group">
-      <label for="field-state" class="control-label">{{ _('State') }}</label>
-      <div class="controls">
-        <select id="field-state" name="state">
+    <div class="form-group control-group">
+      <label for="field-state" class="control-label col-md-3">{{ _('State') }}</label>
+      <div class="controls col-md-9">
+        <select id="field-state" class="form-control" name="state">
           <option value="active" {% if data.get('state', 'none') == 'active' %} selected="selected" {% endif %}>{{ _('Active') }}</option>
           <option value="deleted" {% if data.get('state', 'none') == 'deleted' %} selected="selected" {% endif %}>{{ _('Deleted') }}</option>
         </select>
@@ -90,7 +90,7 @@
     </div>
   {% endif %}
 
-  <p class="form-actions">
+  <div class="form-group form-actions">
     {% block delete_button %}
       {% if data.get('id', None) and h.check_access('harvest_source_delete', {'id': data.id}) and not data.get('state', 'none') == 'deleted' %}
         {% set locale_delete = h.dump_json({'content': _('This will flag the source as deleted but keep all its datasets and previous jobs. Are you sure you want to delete this harvest source?')}) %}
@@ -117,6 +117,6 @@
     {% endblock %}
 
     <input id="save" name="save" value="Save" type="submit" class="btn btn-primary pull-right">
-  </p>
+  </div>
 
 </form>


### PR DESCRIPTION
https://trello.com/c/y5ydUEZx/12-fix-style-issues-on-ckan-publisher-for-28-first-pass

This PR contains a number of frontend tweaks to layouts brought into the views on the upgrade, in order to make the site more legible and a better match against the previous (live) version.

This has involved cloning templates into the extension where necessary, adding required CSS classes throughout templates and doing some style overrides in the custom CSS file.

Some sample screens as they stand now:
![Screenshot 2020-05-19 at 13 37 14](https://user-images.githubusercontent.com/31649453/82327252-0722e580-99d6-11ea-9531-4148f410030e.png)
![Screenshot 2020-05-19 at 13 37 31](https://user-images.githubusercontent.com/31649453/82327254-08541280-99d6-11ea-8046-9b701c260cf8.png)
![Screenshot 2020-05-19 at 13 37 41](https://user-images.githubusercontent.com/31649453/82327256-08eca900-99d6-11ea-8dc3-a002fd4cf6fa.png)
![Screenshot 2020-05-19 at 13 38 14](https://user-images.githubusercontent.com/31649453/82327258-08eca900-99d6-11ea-9a18-c4ba797f209f.png)



