### PR TITLE
Use upstream DGU harvest commits

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -2,7 +2,7 @@
 
 pip=${1-'/usr/bin/env pip'}
 
-ckan_harvest_sha='7b251f0e3b26e9567025b833228676b8801979d0'
+ckan_harvest_sha='1ee4a58e33ef37d67796666de4c8e51f6758d1a1'
 
 ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 
@@ -15,8 +15,8 @@ pycsw_tag='2.4.0'
 
 $pip install -U pip
 
-$pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-harvest/$ckan_harvest_sha/pip-requirements.txt)
-$pip install -U "git+https://github.com/ckan/ckanext-harvest.git@$ckan_harvest_sha#egg=ckanext-harvest"
+$pip install -U $(curl -s https://raw.githubusercontent.com/alphagov/ckanext-harvest/$ckan_harvest_sha/pip-requirements.txt)
+$pip install -U "git+https://github.com/alphagov/ckanext-harvest.git@$ckan_harvest_sha#egg=ckanext-harvest"
 
 $pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckanext-dcat/$ckan_dcat_sha/requirements.txt)
 $pip install -U "git+https://github.com/ckan/ckanext-dcat.git@$ckan_dcat_sha#egg=ckanext-dcat"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 nose-randomly==1.2.6
+pytest==4.6.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ gunicorn
 lxml>=2.3
 numpy==1.16.4
 pandas==0.24.2
+psycopg2==2.7.5
 Shapely>=1.2.13
 sentry-sdk==0.14.1
 xlrd==1.2.0


### PR DESCRIPTION
## What 

In order to use the harvest commits introduced by DGU, we have to pin the dependencies to a commit rather than a release version in ckan/ckanext-harvest.
