### PR TITLE
Pin six to 1.12.0 for ckanext-harvest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ pandas==0.24.2
 psycopg2==2.7.5
 Shapely>=1.2.13
 sentry-sdk==0.14.1
+six==1.12.0
 xlrd==1.2.0


### PR DESCRIPTION
CKAN 2.7.4 installs six 1.10.0, but ckanext-harvest needs six 1.12.0, so pin six to 1.12.0 to fix ckanext-harvest dependency issue.