### PR TITLE
Only remove PII for json element with keys

### DIFF
--- a/ckanext/datagovuk/pii_helpers.py
+++ b/ckanext/datagovuk/pii_helpers.py
@@ -18,7 +18,8 @@ def remove_pii_from_api_search_dataset(data):
                 element['validated_data_dict'] = remove_pii_block(element['validated_data_dict'])
             if 'extras' in element:
                 element['extras'] = remove_pii(element['extras'])
-            element = remove_pii(element)
+            if hasattr(element, 'keys'):
+                element = remove_pii(element)
 
         return json.dumps(json_data)
 

--- a/ckanext/datagovuk/tests/test_pii_helpers.py
+++ b/ckanext/datagovuk/tests/test_pii_helpers.py
@@ -244,6 +244,15 @@ sample_api_search_dataset_without_fields = '''
     ]
 }'''
 
+sample_api_search_dataset_strings = '''
+{
+    "count": 2,
+    "results": [
+        "test-1",
+        "test-2"
+    ]
+}'''
+
 
 class TestRemovePII(unittest.TestCase):
     def test_removes_pii_from_package_search(self):
@@ -264,6 +273,9 @@ class TestRemovePII(unittest.TestCase):
 
         json_validated_data_dict = json.loads(json_res['validated_data_dict'])
         assert not any(elem in PII_LIST for elem in json_validated_data_dict)
+
+    def test_does_not_error_with_strings_in_response(self):
+        remove_pii_from_api_search_dataset(sample_api_search_dataset_strings)
 
     def test_removes_pii_from_api_search_dataset_without_fields_and_does_not_add_fields(self):
         res = remove_pii_from_api_search_dataset(sample_api_search_dataset_without_fields)


### PR DESCRIPTION
## What

Sometimes the response is a list of strings and not json elements, so we should avoid trying to remove PII from the string otherwise we get a 500 server error.