### PR TITLE
Add docker tasks to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,19 @@ node {
       sh("bash -c 'source venv/bin/activate ; ./bin/jenkins-tests.sh'")
     }
 
+    if (govuk.hasDockerfile()) {
+      govuk.dockerBuildTasks([:], "ckan")
+    }
+
     if (env.BRANCH_NAME == 'master') {
       stage('Push release tag') {
         govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
+      }
+
+      if (govuk.hasDockerfile()) {
+        stage("Tag Docker image") {
+          govuk.dockerTagMasterBranch("ckan", env.BRANCH_NAME, env.BUILD_NUMBER)
+        }
       }
 
       stage('Deploy to Integration') {


### PR DESCRIPTION
This adds building a docker image as part of the build process and pushing to docker hub for each branch. It then tags a release image when a master build completes.

This uses tasks set up in https://github.com/alphagov/govuk-jenkinslib/blob/dab23c591306d9f497f1c89651f7b7c0c6cc6967/vars/govuk.groovy