### PR TITLE
Re-align remember me checkbox

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -195,3 +195,7 @@ p.home-footer-text {
 .u-overflow-hidden {
   overflow: hidden;
 }
+
+label.checkbox[for=field-remember] {
+  margin-left: 20px;
+}

--- a/ckanext/datagovuk/templates/user/snippets/login_form.html
+++ b/ckanext/datagovuk/templates/user/snippets/login_form.html
@@ -10,7 +10,10 @@
 
   {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"]) }}
 
-  {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000") }}
+  <div class="form-group">
+    <div class="col-md-3">&nbsp;</div>
+    {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000",  classes=["col-md-9"]) }}
+  </div>
 
   <div class="form-actions">
     {% block login_button %}


### PR DESCRIPTION
https://trello.com/c/i0T7TI7h/149-ie-invisible-remember-me-checkbox

Adding layout divs and padding to align the remember checkbox
with other fields, maintains parity with last version and
ensures the checkbox is visible on IE

### Before and After on IE
![Screenshot 2020-05-21 at 14 52 59](https://user-images.githubusercontent.com/31649453/82565858-02476880-9b73-11ea-9dce-6253273a3507.png)
![Screenshot 2020-05-21 at 14 51 53](https://user-images.githubusercontent.com/31649453/82565882-0a9fa380-9b73-11ea-87d3-6a84a4c6dcc1.png)

### Before and After on Chrome
![Screenshot 2020-05-21 at 14 53 19](https://user-images.githubusercontent.com/31649453/82565938-20ad6400-9b73-11ea-8c3f-138f2a73a16a.png)
![Screenshot 2020-05-21 at 14 51 34](https://user-images.githubusercontent.com/31649453/82565964-286d0880-9b73-11ea-9f86-99eb19b88436.png)

