### PR TITLE
Set the submit button for the new harvest source form to be a button element

### DIFF
--- a/ckanext/datagovuk/templates/source/new_source_form.html
+++ b/ckanext/datagovuk/templates/source/new_source_form.html
@@ -116,7 +116,7 @@
       {% endif %}
     {% endblock %}
 
-    <input id="save" name="save" value="Save" type="submit" class="btn btn-primary pull-right">
+    <button id="save" name="save" type="submit" class="btn btn-primary">Save</button>
   </div>
 
 </form>


### PR DESCRIPTION
## What

Sets the submit button element to be an actual `button` html element instead of an `input` on the new harvest source form (/harvest/new).

## Why

This is part of the work developing the [datagovuk visual regression testing framework](https://github.com/alphagov/datagovuk-visual-regression-tests). Correcting this one inconsistency is going to reduce the work required to make tests run effectively and keep the code as tidy as possible.