### PR TITLE
convert user controller modifications to flask views

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,7 @@ ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='c35e1249cfb3c7b2f1286f433fd51c6fe8f05b72'
 
-ckan_sha='ckan-2.7.4'
+ckan_sha='ckan-2.8.3-dgu'
 
 pycsw_tag='2.4.0'
 

--- a/ckanext/datagovuk/controllers/user.py
+++ b/ckanext/datagovuk/controllers/user.py
@@ -27,6 +27,8 @@ class UserController(UserController):
         from ckanext.datagovuk.schema import user_edit_form_schema
         return user_edit_form_schema()
 
+    # intention: redirect users to dashboard_datasets instead of dashboard
+    # not covered by tests
     def me(self, locale=None):
         if not c.user:
             h.redirect_to(locale=locale, controller='user', action='login',
@@ -34,6 +36,8 @@ class UserController(UserController):
         user_ref = c.userobj.get_reference_preferred_for_uri()
         h.redirect_to(locale=locale, controller='user', action='dashboard_datasets')
 
+    # intention: 8 character limit instead of 4
+    # not covered by tests
     def _get_form_password(self):
         password1 = request.params.getone('password1')
         password2 = request.params.getone('password2')
@@ -47,6 +51,8 @@ class UserController(UserController):
             return password1
         raise ValueError(_('You must provide a password'))
 
+    # intention: allow password to be reset by email, not just username
+    # not covered by tests
     def request_reset(self):
         context = {'model': model, 'session': model.Session, 'user': c.user,
                    'auth_user_obj': c.userobj}

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -203,6 +203,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         from ckanext.datagovuk.views.healthcheck import healthcheck
         from ckanext.datagovuk.views.user import (
             DGUUserEditView,
+            me,
         )
         bp = Blueprint("datagovuk", self.__module__)
 
@@ -211,6 +212,12 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         _user_edit_view = DGUUserEditView.as_view(str(u'edit'))
         bp.add_url_rule(u'/user/edit', view_func=_user_edit_view)
         bp.add_url_rule(u'/user/edit/<id>', view_func=_user_edit_view)
+
+        bp.add_url_rule(u'/user/me', view_func=me)
+        # also monkeypatch occurrence in original module as some views
+        # call it directly instead of redirecting externally
+        import ckan.views.user as ckan_user_views
+        ckan_user_views.me = me
 
         return bp
 
@@ -222,7 +229,6 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         api_search_dataset_controller = 'ckanext.datagovuk.controllers.api:DGUApiController'
         with SubMapper(route_map, controller=user_controller) as m:
             m.connect('register', '/user/register', action='register')
-            m.connect('/user/logged_in', action='logged_in')
             m.connect('/user/reset', action='request_reset')
         route_map.connect('/api/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')
         route_map.connect('/api/3/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -204,6 +204,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         from ckanext.datagovuk.views.user import (
             DGUUserEditView,
             DGUUserRegisterView,
+            DGUUserRequestResetView,
             me,
         )
         bp = Blueprint("datagovuk", self.__module__)
@@ -225,16 +226,17 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         import ckan.views.user as ckan_user_views
         ckan_user_views.me = me
 
+        bp.add_url_rule(
+            u'/user/reset',
+            view_func=DGUUserRequestResetView.as_view(str(u'request_reset')),
+        )
+
         return bp
 
     # IRoutes
 
     def before_map(self, route_map):
-        user_controller = 'ckanext.datagovuk.controllers.user:UserController'
-        healthcheck_controller = 'ckanext.datagovuk.controllers.healthcheck:HealthcheckController'
         api_search_dataset_controller = 'ckanext.datagovuk.controllers.api:DGUApiController'
-        with SubMapper(route_map, controller=user_controller) as m:
-            m.connect('/user/reset', action='request_reset')
         route_map.connect('/api/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')
         route_map.connect('/api/3/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')
         route_map.redirect('/home', '/')

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -201,9 +201,16 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     def get_blueprint(self):
         from ckanext.datagovuk.views.healthcheck import healthcheck
+        from ckanext.datagovuk.views.user import (
+            DGUUserEditView,
+        )
         bp = Blueprint("datagovuk", self.__module__)
 
         bp.add_url_rule(u"/healthcheck", view_func=healthcheck)
+
+        _user_edit_view = DGUUserEditView.as_view(str(u'edit'))
+        bp.add_url_rule(u'/user/edit', view_func=_user_edit_view)
+        bp.add_url_rule(u'/user/edit/<id>', view_func=_user_edit_view)
 
         return bp
 
@@ -216,8 +223,6 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         with SubMapper(route_map, controller=user_controller) as m:
             m.connect('register', '/user/register', action='register')
             m.connect('/user/logged_in', action='logged_in')
-            m.connect('/user/edit', action='edit')
-            m.connect('/user/edit/{id:.*}', action='edit')
             m.connect('/user/reset', action='request_reset')
         route_map.connect('/api/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')
         route_map.connect('/api/3/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -203,11 +203,17 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         from ckanext.datagovuk.views.healthcheck import healthcheck
         from ckanext.datagovuk.views.user import (
             DGUUserEditView,
+            DGUUserRegisterView,
             me,
         )
         bp = Blueprint("datagovuk", self.__module__)
 
         bp.add_url_rule(u"/healthcheck", view_func=healthcheck)
+
+        bp.add_url_rule(
+            u"/user/register",
+            view_func=DGUUserRegisterView.as_view(str(u'register')),
+        )
 
         _user_edit_view = DGUUserEditView.as_view(str(u'edit'))
         bp.add_url_rule(u'/user/edit', view_func=_user_edit_view)
@@ -228,7 +234,6 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         healthcheck_controller = 'ckanext.datagovuk.controllers.healthcheck:HealthcheckController'
         api_search_dataset_controller = 'ckanext.datagovuk.controllers.api:DGUApiController'
         with SubMapper(route_map, controller=user_controller) as m:
-            m.connect('register', '/user/register', action='register')
             m.connect('/user/reset', action='request_reset')
         route_map.connect('/api/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')
         route_map.connect('/api/3/search/dataset', controller=api_search_dataset_controller, action='api_search_dataset')

--- a/ckanext/datagovuk/tests/action/test_update.py
+++ b/ckanext/datagovuk/tests/action/test_update.py
@@ -5,7 +5,7 @@ from ckan.tests import factories, helpers
 from ckanext.datagovuk.action.update import dgu_user_update
 
 
-class TestWhenUpdatingUser:
+class TestWhenUpdatingUser(object):
 
     def setup(self):
         helpers.reset_db()

--- a/ckanext/datagovuk/tests/test_ckan_patches.py
+++ b/ckanext/datagovuk/tests/test_ckan_patches.py
@@ -10,16 +10,16 @@ from ckanext.datagovuk.tests.db_test import DBTest
 
 class TestLogin(DBTest):
     def test_validate_password__ok(self):
-        user_dict = factories.User(password='hello')
+        user_dict = factories.User(password='helloworld')
         user = model.User.get(user_dict['id'])
 
-        self.assertTrue(user.validate_password('hello'))
+        self.assertTrue(user.validate_password('helloworld'))
 
     def test_validate_password__wrong_password(self):
-        user_dict = factories.User(password='hello')
+        user_dict = factories.User(password='helloworld')
         user = model.User.get(user_dict['id'])
 
-        self.assertFalse(user.validate_password('wrong'))
+        self.assertFalse(user.validate_password('goodbyeworld'))
 
     def test_validate_password__drupal_ok(self):
         # Drupal hash

--- a/ckanext/datagovuk/tests/test_healthcheck.py
+++ b/ckanext/datagovuk/tests/test_healthcheck.py
@@ -1,7 +1,12 @@
 import unittest
-from ckanext.datagovuk.controllers.healthcheck import HealthcheckController
+
+import ckan.tests.helpers as helpers
+
 
 class TestHealthcheck(unittest.TestCase):
-    def test_healthcheck_controller(self):
-        healthcheck = HealthcheckController()
-        self.assertEqual(healthcheck.healthcheck(), 'OK')
+    def test_healthcheck(self):
+        app = helpers._get_test_app()
+        with app.flask_app.test_client() as client:
+            resp = client.get("/healthcheck")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.get_data(as_text=True), "OK")

--- a/ckanext/datagovuk/tests/test_paths.py
+++ b/ckanext/datagovuk/tests/test_paths.py
@@ -1,5 +1,6 @@
 from bs4 import BeautifulSoup
 import unittest
+
 import ckan.plugins.toolkit as toolkit
 import ckan.tests.helpers as helpers
 import ckanext.datagovuk.plugin as plugin
@@ -19,8 +20,10 @@ class TestPaths(unittest.TestCase):
         self.assertEqual(path, '/harvest')
 
     def test_healthcheck_path(self):
-        path = toolkit.url_for('healthcheck')
-        self.assertEqual(path, '/healthcheck')
+        app = helpers._get_test_app()
+        with app.flask_app.test_request_context():
+            path = toolkit.url_for('datagovuk.healthcheck')
+            self.assertEqual(path, '/healthcheck')
 
     def test_home_path_redirects_to_index(self):
         app = helpers._get_test_app()

--- a/ckanext/datagovuk/tests/test_user.py
+++ b/ckanext/datagovuk/tests/test_user.py
@@ -180,3 +180,29 @@ class TestUserMe(helpers.FunctionalTestBase, DBTest):
             response.location,
             urljoin(config.get('ckan.site_url'), url_for("dashboard.datasets")),
         )
+
+
+class TestRegisterUser(helpers.FunctionalTestBase, DBTest):
+    def test_register_a_user_blocked(self):
+        app = helpers._get_test_app()
+        response = app.post(
+            url_for("user.register"),
+            params={
+                "name": 'newuser',
+                'fullname': 'New User',
+                'email': 'test@gov.uk',
+                'password1': 'TestPassword1',
+                'password2': 'TestPassword1',
+                "save": "1",
+            },
+            status=403,
+        )
+        self.assertFalse(model.User.by_email("test@gov.uk"))
+
+    def test_get_still_works(self):
+        app = helpers._get_test_app()
+        response = app.get(
+            url_for("user.register"),
+            status=200,
+        )
+        self.assertIn("contact us", response.body.lower())

--- a/ckanext/datagovuk/tests/test_user.py
+++ b/ckanext/datagovuk/tests/test_user.py
@@ -1,22 +1,21 @@
-from routes import url_for
 
 import ckan.plugins
 from ckan import model
 from ckan.tests import factories, helpers
-from ckanext.datagovuk.controllers.user import UserController
+from ckan.plugins.toolkit import url_for
 from ckanext.datagovuk.tests.db_test import DBTest
 
 webtest_submit = helpers.webtest_submit
 submit_and_follow = helpers.submit_and_follow
 
 
-class TestUserController(helpers.FunctionalTestBase, DBTest):
+class TestEditUser(helpers.FunctionalTestBase, DBTest):
     def test_edit_user_form(self):
-        user = factories.User(password='pass')
+        user = factories.User(password='pass1234')
         app = self._get_test_app()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = app.get(
-            url=url_for(controller='user', action='edit'),
+            url=url_for("user.edit"),
             extra_environ=env,
         )
 
@@ -32,7 +31,7 @@ class TestUserController(helpers.FunctionalTestBase, DBTest):
         # Modify the values
         form['fullname'] = 'user fullname'
         form['email'] = 'test@test.com'
-        form['old_password'] = 'pass'
+        form['old_password'] = 'pass1234'
         form['password1'] = 'Abc12345'
         form['password2'] = 'Abc12345'
         response = submit_and_follow(app, form, env, 'save')
@@ -42,18 +41,18 @@ class TestUserController(helpers.FunctionalTestBase, DBTest):
         self.assertEqual(user.email, 'test@test.com')
 
     def test_edit_user_form_password_too_short(self):
-        user = factories.User(password='pass')
+        user = factories.User(password='pass1234')
         app = self._get_test_app()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = app.get(
-            url=url_for(controller='user', action='edit'),
+            url=url_for("user.edit"),
             extra_environ=env,
         )
 
         form = response.forms['user-edit-form']
 
         # Modify the values
-        form['old_password'] = 'pass'
+        form['old_password'] = 'pass1234'
         form['password1'] = 'Abc1234'
         form['password2'] = 'Abc1234'
         response = webtest_submit(form, 'save', status=200, extra_environ=env)
@@ -61,18 +60,18 @@ class TestUserController(helpers.FunctionalTestBase, DBTest):
         self.assertIn('Your password must be 8 characters or longer', response)
 
     def test_edit_user_form_password_no_lower_case(self):
-        user = factories.User(password='pass')
+        user = factories.User(password='pass1234')
         app = self._get_test_app()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = app.get(
-            url=url_for(controller='user', action='edit'),
+            url=url_for("user.edit"),
             extra_environ=env,
         )
 
         form = response.forms['user-edit-form']
 
         # Modify the values
-        form['old_password'] = 'pass'
+        form['old_password'] = 'pass1234'
         form['password1'] = 'ABC12345'
         form['password2'] = 'ABC12345'
         response = webtest_submit(form, 'save', status=200, extra_environ=env)
@@ -80,18 +79,18 @@ class TestUserController(helpers.FunctionalTestBase, DBTest):
         self.assertIn('Your password must contain at least one upper and one lower case character', response)
 
     def test_edit_user_form_password_no_upper_case(self):
-        user = factories.User(password='pass')
+        user = factories.User(password='pass1234')
         app = self._get_test_app()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = app.get(
-            url=url_for(controller='user', action='edit'),
+            url=url_for("user.edit"),
             extra_environ=env,
         )
 
         form = response.forms['user-edit-form']
 
         # Modify the values
-        form['old_password'] = 'pass'
+        form['old_password'] = 'pass1234'
         form['password1'] = 'abc12345'
         form['password2'] = 'abc12345'
         response = webtest_submit(form, 'save', status=200, extra_environ=env)
@@ -99,18 +98,18 @@ class TestUserController(helpers.FunctionalTestBase, DBTest):
         self.assertIn('Your password must contain at least one upper and one lower case character', response)
 
     def test_edit_user_form_passwords_not_matching(self):
-        user = factories.User(password='pass')
+        user = factories.User(password='pass1234')
         app = self._get_test_app()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = app.get(
-            url=url_for(controller='user', action='edit'),
+            url=url_for("user.edit"),
             extra_environ=env,
         )
 
         form = response.forms['user-edit-form']
 
         # Modify the values
-        form['old_password'] = 'pass'
+        form['old_password'] = 'pass1234'
         form['password1'] = 'Abc123456'
         form['password2'] = 'Abc12345'
         response = webtest_submit(form, 'save', status=200, extra_environ=env)
@@ -118,18 +117,18 @@ class TestUserController(helpers.FunctionalTestBase, DBTest):
         self.assertIn('The passwords you entered do not match', response)
 
     def test_edit_user_form_password_missing(self):
-        user = factories.User(password='pass')
+        user = factories.User(password='pass1234')
         app = self._get_test_app()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = app.get(
-            url=url_for(controller='user', action='edit'),
+            url=url_for("user.edit"),
             extra_environ=env,
         )
 
         form = response.forms['user-edit-form']
 
         # Modify the values
-        form['old_password'] = 'pass'
+        form['old_password'] = 'pass1234'
         form['password1'] = ''
         form['password2'] = ''
         response = webtest_submit(form, 'save', status=200, extra_environ=env)

--- a/ckanext/datagovuk/views/healthcheck.py
+++ b/ckanext/datagovuk/views/healthcheck.py
@@ -1,0 +1,3 @@
+
+def healthcheck():
+    return "OK"

--- a/ckanext/datagovuk/views/user.py
+++ b/ckanext/datagovuk/views/user.py
@@ -3,6 +3,7 @@ from ckan.plugins.toolkit import _, redirect_to, abort
 from ckan.views.user import (
     before_request,
     EditView,
+    RegisterView,
 )
 
 from ckanext.datagovuk.schema import user_edit_form_schema
@@ -27,6 +28,14 @@ class DGUUserEditView(_UserBeforeRequestMixin, EditView):
         context, id_ = super(DGUUserEditView, self)._prepare(*args, **kwargs)
         context[u"schema"] = user_edit_form_schema()
         return context, id_
+
+
+class DGUUserRegisterView(_UserBeforeRequestMixin, RegisterView):
+    """
+    A RegisterView that disables the POST view
+    """
+    def post(self, *args, **kwargs):
+        abort(403)
 
 
 def me():

--- a/ckanext/datagovuk/views/user.py
+++ b/ckanext/datagovuk/views/user.py
@@ -1,3 +1,5 @@
+from ckan.common import g
+from ckan.plugins.toolkit import _, redirect_to, abort
 from ckan.views.user import (
     before_request,
     EditView,
@@ -25,3 +27,12 @@ class DGUUserEditView(_UserBeforeRequestMixin, EditView):
         context, id_ = super(DGUUserEditView, self)._prepare(*args, **kwargs)
         context[u"schema"] = user_edit_form_schema()
         return context, id_
+
+
+def me():
+    """
+    A slight variation on the default me() which prefers `dashboard.datasets`
+    over `dashboard.index`
+    """
+    route = u'dashboard.datasets' if g.user else u'user.login'
+    return redirect_to(route)

--- a/ckanext/datagovuk/views/user.py
+++ b/ckanext/datagovuk/views/user.py
@@ -1,0 +1,27 @@
+from ckan.views.user import (
+    before_request,
+    EditView,
+)
+
+from ckanext.datagovuk.schema import user_edit_form_schema
+
+
+class _UserBeforeRequestMixin(object):
+    """
+    Use with MethodViews to ensure ckan.views.user.before_request is
+    called before processing requests when view is not a member of the
+    ckan.views.user.user blueprint to which it is normally applied.
+    """
+    def dispatch_request(self, *args, **kwargs):
+        ret = before_request()
+        return ret or super(_UserBeforeRequestMixin, self).dispatch_request(*args, **kwargs)
+
+
+class DGUUserEditView(_UserBeforeRequestMixin, EditView):
+    """
+    An EditView that adds extra password policy policing
+    """
+    def _prepare(self, *args, **kwargs):
+        context, id_ = super(DGUUserEditView, self)._prepare(*args, **kwargs)
+        context[u"schema"] = user_edit_form_schema()
+        return context, id_

--- a/ckanext/datagovuk/views/user.py
+++ b/ckanext/datagovuk/views/user.py
@@ -1,9 +1,16 @@
+from six import text_type
+
 from ckan.common import g
+import ckan.lib.helpers as h
+import ckan.lib.mailer as mailer
+import ckan.logic as logic
+import ckan.model as model
 from ckan.plugins.toolkit import _, redirect_to, abort
 from ckan.views.user import (
     before_request,
     EditView,
     RegisterView,
+    RequestResetView,
 )
 
 from ckanext.datagovuk.schema import user_edit_form_schema
@@ -36,6 +43,61 @@ class DGUUserRegisterView(_UserBeforeRequestMixin, RegisterView):
     """
     def post(self, *args, **kwargs):
         abort(403)
+
+
+class DGUUserRequestResetView(_UserBeforeRequestMixin, RequestResetView):
+    """
+    A RequestResetView that will also allow password to be reset by
+    providing email address, not just username
+    """
+    def post(self):
+        context, data_dict = self._prepare()
+        id = data_dict[u'id']
+
+        context = {u'model': model, u'user': g.user}
+        user_obj = None
+        try:
+            logic.get_action(u'user_show')(context, data_dict)
+            user_obj = context[u'user_obj']
+        except logic.NotFound:
+            # Try getting the user by email
+            user_accounts = model.User.by_email(id)
+            if user_accounts:
+                user_obj = user_accounts[0]
+
+        if not user_obj:
+            # Try searching the user
+            if id and len(id) > 2:
+                user_list = logic.get_action(u'user_list')(context, {
+                    u'id': id
+                })
+                if len(user_list) == 1:
+                    # This is ugly, but we need the user object for the
+                    # mailer,
+                    # and user_list does not return them
+                    data_dict[u'id'] = user_list[0][u'id']
+                    logic.get_action(u'user_show')(context, data_dict)
+                    user_obj = context[u'user_obj']
+                elif len(user_list) > 1:
+                    h.flash_error(_(u'"%s" matched several users') % (id))
+                else:
+                    h.flash_error(_(u'No such user: %s') % id)
+            else:
+                h.flash_error(_(u'No such user: %s') % id)
+
+        if user_obj:
+            try:
+                # FIXME: How about passing user.id instead? Mailer already
+                # uses model and it allow to simplify code above
+                mailer.send_reset_link(user_obj)
+                h.flash_success(
+                    _(u'Please check your inbox for '
+                      u'a reset code.'))
+                return h.redirect_to(u'home.index')
+            except mailer.MailerException as e:
+                h.flash_error(_(u'Could not send reset link: %s') %
+                              text_type(e))
+        return self.get()
 
 
 def me():


### PR DESCRIPTION
https://trello.com/c/S78qrTJA

I've separated this up into a number of commits to try and make it make sense, so I suggest looking at the commit comments.

Some modifications have been ported, some have been found to be unnecessary.

I've tried to add test coverage to every modification I ported across, and hopefully add some tests to prove the unneccesary ...ness of thing's I've removed.

Still to do: api endpoint modification porting. Then we should be able to remove `before_map()` entirely.