### PR TITLE
Block POSTs on user/register

### DIFF
--- a/ckanext/datagovuk/controllers/user.py
+++ b/ckanext/datagovuk/controllers/user.py
@@ -18,6 +18,7 @@ NotAuthorized = logic.NotAuthorized
 ValidationError = logic.ValidationError
 UsernamePasswordError = logic.UsernamePasswordError
 
+
 class UserController(UserController):
     def _new_form_to_db_schema(self):
         from ckanext.datagovuk.schema import user_new_form_schema
@@ -102,3 +103,7 @@ class UserController(UserController):
                                   unicode(e))
         return render('user/request_reset.html')
 
+    def new(self, data=None, errors=None, error_summary=None):
+        if request.method == 'POST':
+            abort(403, _('Unauthorized to create a user')) 
+        return super(UserController, self).new(data=data, errors=errors, error_summary=error_summary)

--- a/ckanext/datagovuk/tests/test_user.py
+++ b/ckanext/datagovuk/tests/test_user.py
@@ -41,6 +41,30 @@ class TestUserController(helpers.FunctionalTestBase, DBTest):
         self.assertEqual(user.fullname, 'user fullname')
         self.assertEqual(user.email, 'test@test.com')
 
+    def test_create_user_via_post_responds_403(self):
+        app = self._get_test_app()
+        app.post(
+            url=url_for(controller='user', action='register'),
+            params={
+                "name": 'newuser',
+                'fullname': 'New User',
+                'email': 'test@gov.uk',
+                'password1': 'TestPassword1',
+                'password2': 'TestPassword1',
+                "save": "1",
+            },
+            status=403
+        )
+        self.assertFalse(model.User.by_email("test@gov.uk"))
+
+    def test_create_user_via_get_shows_dgu_register_page(self):
+        app = self._get_test_app()
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+            status=200
+        )
+        assert 'https://data.gov.uk/support' in response
+
     def test_edit_user_form_password_too_short(self):
         user = factories.User(password='pass')
         app = self._get_test_app()


### PR DESCRIPTION
## What 

Although the registration form has been replaced, it was still possible to do a POST on the /user/register endpoint to create a user.

## Reference 

https://trello.com/c/7HEtFQiE/2010-3-investigate-and-fix-account-creation-disabled-but-not-really