### PR TITLE
Fix button dropdown

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -197,6 +197,10 @@ p.home-footer-text {
   overflow: hidden;
 }
 
+.u-overflow-visible {
+  overflow: visible;
+}
+
 label.checkbox[for=field-remember] {
   margin-left: 20px;
 }

--- a/ckanext/datagovuk/templates/source/new_source_form.html
+++ b/ckanext/datagovuk/templates/source/new_source_form.html
@@ -90,13 +90,13 @@
     </div>
   {% endif %}
 
-  <div class="form-group form-actions">
+  <div class="form-group form-actions u-overflow-visible">
     {% block delete_button %}
       {% if data.get('id', None) and h.check_access('harvest_source_delete', {'id': data.id}) and not data.get('state', 'none') == 'deleted' %}
         {% set locale_delete = h.dump_json({'content': _('This will flag the source as deleted but keep all its datasets and previous jobs. Are you sure you want to delete this harvest source?')}) %}
         {% set locale_clear = h.dump_json({'content': _('Warning: Apart from deleting this source, this command will remove all its datasets, as well as all previous job reports. Are you sure you want to continue?')}) %}
   <div class="dropdown btn-group">
-    <a href="#" class="btn btn-danger dropdown-toggle" data-toggle="dropdown">
+    <a href="" class="btn btn-danger dropdown-toggle" data-toggle="dropdown">
       {{ _('Delete') }}
       <span class="caret"></span>
     </a>

--- a/ckanext/datagovuk/templates/source/new_source_form.html
+++ b/ckanext/datagovuk/templates/source/new_source_form.html
@@ -96,10 +96,10 @@
         {% set locale_delete = h.dump_json({'content': _('This will flag the source as deleted but keep all its datasets and previous jobs. Are you sure you want to delete this harvest source?')}) %}
         {% set locale_clear = h.dump_json({'content': _('Warning: Apart from deleting this source, this command will remove all its datasets, as well as all previous job reports. Are you sure you want to continue?')}) %}
   <div class="dropdown btn-group">
-    <a href="" class="btn btn-danger dropdown-toggle" data-toggle="dropdown">
+    <button class="btn btn-danger dropdown-toggle" data-toggle="dropdown">
       {{ _('Delete') }}
       <span class="caret"></span>
-    </a>
+    </button>
     <ul class="dropdown-menu">
       <li>
         <a href="{% url_for 'harvest_delete', id=data.name %}" data-module="confirm-action" data-module-i18n="{{ locale_delete }}">


### PR DESCRIPTION
https://trello.com/c/mgX7eAdl/168-harvest-source-delete-button-broken

The delete button on harvests should reveal two different delete options
when clicked, but is failing due to the implementation using a hash symbol
in the button link's href. This removes the hash and then adds styles to
give the dropdown options space on screen when it is clicked.

It seems the main issue is caused by some level of clash introduced between certain versions of bootstrap and jquery (see bug reports in the wild such as this: https://www.drupal.org/project/bootstrap_mint/issues/2957269)  and the bug reached beyond our own extension. Luckily the fix is extremely simple (remove the #) within a template we already override. 

Before the fix the delete button jumps the user to the top of the screen and does nothing, after the fix it reveals delete options thus:

![Screenshot 2020-06-03 at 14 08 33](https://user-images.githubusercontent.com/31649453/83643653-3033a080-a5a8-11ea-9b93-46a840e52ae3.png)
