### PR TITLE
Fix status field width

### DIFF
--- a/ckanext/datagovuk/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/datagovuk/templates/package/snippets/package_basic_fields.html
@@ -101,8 +101,8 @@
 
   {% if data.id and h.check_access('package_delete', {'id': data.id}) and data.state != 'active' %}
   <div class="form-group control-medium">
-    <label for="field-state" class="control-label">{{ _('State') }}</label>
-    <div class="controls">
+    <label for="field-state" class="control-label col-md-3">{{ _('State') }}</label>
+    <div class="controls col-md-4">
       <select class="form-control" id="field-state" name="state">
         <option value="active" {% if data.get('state', 'none') == 'active' %} selected="selected" {% endif %}>{{ _('Active') }}</option>
         <option value="deleted" {% if data.get('state', 'none') == 'deleted' %} selected="selected" {% endif %}>{{ _('Deleted') }}</option>


### PR DESCRIPTION
## What
Adds bootstrap column classes to the label and input elements for the status form fields.

**Card:** https://trello.com/c/87ABxr5Q/198-add-data-state-bug

### Before
![Screenshot_2020-06-11_at_16 02 29](https://user-images.githubusercontent.com/64783893/84513880-02dea500-acc2-11ea-9f80-64411ae31ea2.png)

### After
![Screenshot 2020-06-12 at 15 34 10](https://user-images.githubusercontent.com/64783893/84513985-315c8000-acc2-11ea-97a2-f9c47e12b1bf.png)
