### PR TITLE
Minor styling tweak on user management form

### DIFF
--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -1,6 +1,6 @@
 {% import 'macros/form.html' as form %}
 
-<form id="user-edit-form" class="dataset-form form-horizontal" method="post" action="{{ action }}">
+<form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}">
   {{ form.errors(error_summary) }}
 
   <fieldset>


### PR DESCRIPTION
## What
Removes the class `form-horizontal` from the form tag on the user management view (/user/edit[username]).

## Why
There are several styles associated with `.form-horizontal` and other form elements and tags that result in a slightly different display for users. Removing this class ensures that it looks and behaves like other forms across the site.

**Card:** https://trello.com/c/xySUeU3d/197-user-management-page-form-positioning