### PR TITLE
Set the submit button for the new harvest source form to be a button element

### DIFF
--- a/ckanext/datagovuk/templates/source/new_source_form.html
+++ b/ckanext/datagovuk/templates/source/new_source_form.html
@@ -116,7 +116,7 @@
       {% endif %}
     {% endblock %}
 
-    <input id="save" name="save" value="Save" type="submit" class="btn btn-primary pull-right">
+    <button id="save" name="save" type="submit" class="btn btn-primary">Save</button>
   </p>
 
 </form>


### PR DESCRIPTION
## What
This is a near carbon copy of this PR https://github.com/alphagov/ckanext-datagovuk/pull/367 only for CKAN 2.7 instead of 2.8

## Why
Very similar to the previous card, this inconsistency in form markup is interfering with VRT implementation for CKAN 2.7. Changing this submit element to a button fixes the problem.

**Card:** https://trello.com/c/L5itq14S/205-replace-input-with-button-on-the-new-harvest-source-form-for-ckan-27