### PR TITLE
Fix jenkins CI for master-2.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ library("govuk")
 
 REPOSITORY = 'ckanext-datagovuk'
 
-node {
+node ('ci-agent-7 || ci-agent-8') {
 
   try {
     stage('Checkout') {

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -24,9 +24,9 @@ $pip install -U "git+https://github.com/ckan/ckanext-dcat.git@$ckan_dcat_sha#egg
 $pip install -U $(curl -s https://raw.githubusercontent.com/$ckan_spatial_fork/ckanext-spatial/$ckan_spatial_sha/pip-requirements.txt)
 $pip install -U "git+https://github.com/$ckan_spatial_fork/ckanext-spatial.git@$ckan_spatial_sha#egg=ckanext-spatial"
 
-$pip install -U $(curl -s https://raw.githubusercontent.com/ckan/ckan/$ckan_sha/requirement-setuptools.txt)
-$pip install -r https://raw.githubusercontent.com/ckan/ckan/$ckan_sha/requirements.txt
-$pip install -Ue "git+https://github.com/ckan/ckan.git@$ckan_sha#egg=ckan"
+$pip install -U $(curl -s https://raw.githubusercontent.com/alphagov/ckan/$ckan_sha/requirement-setuptools.txt)
+$pip install -r https://raw.githubusercontent.com/alphagov/ckan/$ckan_sha/requirements.txt
+$pip install -Ue "git+https://github.com/alphagov/ckan.git@$ckan_sha#egg=ckan"
 
 $pip install -r requirements.txt
 

--- a/bin/jenkins-tests.sh
+++ b/bin/jenkins-tests.sh
@@ -4,10 +4,23 @@ set -ex
 
 venv/bin/pip install -r venv/src/ckan/dev-requirements.txt
 venv/bin/pip install -r dev-requirements.txt
-dropdb ckan_test; createdb ckan_test
+
+DB_NAME="ckanext_dgu_$(date -u -Ins | tr -dc 0-9)"
+
+createdb $DB_NAME
+
+echo "\n[app:main]\nsqlalchemy.url = postgresql:///$DB_NAME\nsolr_url = http://localhost:8983/solr/$DB_NAME\n" >> test-jenkins.ini
+
+curl "http://localhost:8983/solr/admin/cores?action=CREATE&name=$DB_NAME&configSet=ckan28"
+
 venv/bin/python setup.py develop
 paster --plugin=ckan db init -c test-jenkins.ini
 paster --plugin=ckanext-harvest harvester initdb -c test-jenkins.ini
 
 export TEST_CKAN_INI=test-jenkins.ini
 bin/run-tests.sh
+
+# deliberately only drop DBs if tests pass. otherwise leave DBs
+# as it may help in diagnosing failure
+dropdb $DB_NAME
+curl "http://localhost:8983/solr/admin/cores?action=UNLOAD&core=$DB_NAME&deleteIndex=true&deleteDataDir=true&deleteInstanceDir=true"

--- a/test-jenkins.ini
+++ b/test-jenkins.ini
@@ -6,8 +6,9 @@ port = 5000
 [app:main]
 use = config:test.ini
 
-sqlalchemy.url = postgresql:///ckan_test
-solr_url = http://127.0.0.1:8983/solr
+# appended dynamically
+#sqlalchemy.url = 
+#solr_url = 
 
 ckan.datastore.write_url = postgresql:///datastore_test
 ckan.datastore.read_url = postgresql:///datastore_test


### PR DESCRIPTION
~This should eventually be the PR that fixes jenkins ci for the `master-2.8` branch. It is nowhere near ready yet, but I need to create a PR to be able to poke jenkins from.~

https://trello.com/c/zLLNaKtv

This allows our `master-2.8` branch to have CI tests pass. To do this I needed to change the setup of solr on some of the CI agents (`ci-agent-7` and `ci-agent-8`). This PR restricts this branch to running on those machines. It also changes the way the tests handle/expect resources to be set up on the agent's database and solr instance. Rather than expecting a single, fixed database/solr core (which caused various problems and potentially would have prevented simultaneous ci runs), it now creates a uniquely named postgres database and solr core before each run and removes them afterwards.

Though in the 2.8 branch we've moved to a "multicore" solr, with the ability to create & destroy cores at runtime, this still doesn't give us the same amount of flexibility as we have with postgres databases. We have to name a specific `configSet` to be used at core creation time (in this case `ckan28`) which the solr installation must know about (we put this in place with puppet currently). This `configSet` includes the schema that will be used for the core.

ckan 2.9 appears to be able to use another form of schema management for solr which is something a little closer to the flexibility of postgres databases but that's some way away.

I also realized we had been trying to fetch our custom ckan branches from the `ckan` fork rather than `alphagov` so fixed that.

Of course, it's still not perfect as CI because we're still pointing at moving targets in `install-dependencies.sh`, so two test runs could have different results depending on what gets merged to external repos.