### PR TITLE
Jenkinsfile: ban jenkins agents 7 and 8 from running tests for this branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ library("govuk")
 
 REPOSITORY = 'ckanext-datagovuk'
 
-node {
+node ('!(ci-agent-7 || ci-agent-8)') {
 
   try {
     stage('Checkout') {


### PR DESCRIPTION
7 and 8 are being used for ckan 2.8 branch testing and have a different solr setup.