### PR TITLE
jenkins test setup: don't fail if ckan_test db can't be dropped

### DIFF
--- a/bin/jenkins-tests.sh
+++ b/bin/jenkins-tests.sh
@@ -4,7 +4,8 @@ set -ex
 
 venv/bin/pip install -r venv/src/ckan/dev-requirements.txt
 venv/bin/pip install -r dev-requirements.txt
-dropdb ckan_test; createdb ckan_test
+dropdb ckan_test || true  # fine if it doesn't exist
+createdb ckan_test
 venv/bin/python setup.py develop
 paster --plugin=ckan db init -c test-jenkins.ini
 paster --plugin=ckanext-harvest harvester initdb -c test-jenkins.ini


### PR DESCRIPTION
This is probably just because it doesn't exist. that's fine.

This is a non-ideal way of handling resource setup anyway, and is replaced in our 2.8 branch. Fix this up temporarily in the 2.7 branch for now, because `master`'s CI is currently failing.