### PR TITLE
Fix slug preview field height on IE11

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -204,3 +204,7 @@ p.home-footer-text {
 label.checkbox[for=field-remember] {
   margin-left: 20px;
 }
+
+input {
+  height: 1.75em;
+}


### PR DESCRIPTION
## What
Add height attribute for inputs explicitly specifying their height.

## Why
On IE11, firefox and opera, input fields don't respect line height so you need to apply an explicit height attribute (see here https://joshnh.com/weblog/line-height-doesnt-work-as-expected-on-inputs/).

### Before (IE11)
<img width="338" alt="Screenshot 2020-07-20 at 12 43 55" src="https://user-images.githubusercontent.com/64783893/87939418-f2270900-ca8f-11ea-8d6b-b3dfdd89a735.png">

### After (IE11)
<img width="339" alt="Screenshot 2020-07-20 at 12 43 09" src="https://user-images.githubusercontent.com/64783893/87939435-fb17da80-ca8f-11ea-8978-314c358c797e.png">

**Card:** https://trello.com/c/65KpXkRC/151-ie-slug-field-height
