### PR TITLE
Explicitly set masthead margin bottom

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -8,6 +8,10 @@ body {
   background: #FFF;
 }
 
+.masthead {
+  margin-bottom: 0;
+}
+
 .masthead .navigation .nav-pills li a,
 .masthead .navigation .nav-pills li.active a {
 


### PR DESCRIPTION
## What
Explicitly set an override of margin: 0 for the masthead class (found on the header of the ckan admin panel)

## Why
`.masthead` uses initial as a way to set margin-bottom, which isn't recognised in IE. Explicitly setting it stops the header from reverting back to a styling rule that adds a 20px margin to the header, creating this awkward white space on IE.

### Before
<img width="501" alt="Screenshot 2020-07-20 at 14 20 40" src="https://user-images.githubusercontent.com/64783893/87946056-75009180-ca99-11ea-8c43-448a7df190bf.png">

### After
<img width="440" alt="Screenshot 2020-07-20 at 14 21 42" src="https://user-images.githubusercontent.com/64783893/87946076-792caf00-ca99-11ea-8b41-8dba98964787.png">

**Card:** https://trello.com/c/XMb9WSr8/148-ie-extra-header-margin