### PR TITLE
Upgrade CKAN 2.7.8 to add a number of fixes

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,8 @@ ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='46b706549aaf13a4ef2451d6185d7a90a75aeb0f'
 
-ckan_sha='ckan-2.7.7'
+# CKAN release 2.7.8
+ckan_sha='7a8801beac120bdcd99f1b7a63c248c519a35d05'
 
 pycsw_tag='2.4.0'
 


### PR DESCRIPTION
## What

Upgrade CKAN to 2.7.8 for a number of fixes and also to fix the release to a particular ckan sha.

