### PR TITLE
Revert "Upgrade CKAN 2.7.8 to add a number of fixes"

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,8 +9,7 @@ ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='46b706549aaf13a4ef2451d6185d7a90a75aeb0f'
 
-# CKAN release 2.7.8
-ckan_sha='7a8801beac120bdcd99f1b7a63c248c519a35d05'
+ckan_sha='ckan-2.7.7'
 
 pycsw_tag='2.4.0'
 


### PR DESCRIPTION
Reverts alphagov/ckanext-datagovuk#437

## What 

Handling of PII was broken due to the way that extras were being output, this affects API calls from Publish app which will mean that Find will not be in sync with CKAN data until the revert or pii_helper code is updated to handle the change in data format.

No longer - 
```
            "extras": {
                "foi-email": "test-foi@example.com",
                "contact-name": "Test User",
                "contact-email": "test@example.com"
            },
```
but 
```
            "extras": [
                {
                    "key": u 'foi-email',
                    "value": "test-foi@example.com"
                },
                {
                    "key": u 'contact-name',
                    "value": "Test User"
                },
                {
                    "key": u 'contact-email',
                    "value": "test@example.com"
                }
            ],
```