### PR TITLE
Don't send events to Sentry on Integration / local

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -1,4 +1,5 @@
 import logging
+from pylons import config
 
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
@@ -279,12 +280,16 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     # IMiddleware
 
+    def before_send(self, event, hint):
+        return None if [i for i in ['localhost', 'integration'] if i in config.get('ckan.site_url')] \
+            else event
+
     def make_middleware(self, app, config):
         # we get this called twice, once for Flask and once for Pylons
         if isinstance(app, PylonsApp):
             return SentryWsgiMiddleware(app)
         else:
-            sentry_sdk.init(integrations=[FlaskIntegration()])
+            sentry_sdk.init(before_send=self.before_send, integrations=[FlaskIntegration()])
             return app
 
     # IResourceController


### PR DESCRIPTION
## What

Prevent Sentry errors from being sent on Integration, as it is being used for reindexing which is throwing up lots of errors and Integration is often used to try things out which potentially will throw errors. 
As Sentry is rate limited these errors will cause other apps in govuk to not have their errors shown.

## Reference 

https://trello.com/c/R4BTJDZy/249-stop-errors-from-reindexing-reaching-sentry-on-integration