### PR TITLE
DatagovukPlugin: add before_index method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,13 @@ Config Settings
 
 Document any optional config settings here.
 
+ - ``ckan.datagovuk.trim_strings_for_index_limit``: when indexing packages, string
+   fields will be truncated to this length unless they are known to be under a
+   text-indexed key. Solr 6 has a field limit of 32k for string fields, but note
+   that our truncation is applied per-json-value, and a Solr value can contain
+   multiple json values which then get squashed together to a single field value,
+   so using a number under half Solr's limit is wise.
+
 
 ------------------------
 Development Installation

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -7,7 +7,7 @@ ckan_harvest_sha='73db5f1ee67fc86521cfd1861b5d699ff45b1e33'
 ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 
 ckan_spatial_fork='alphagov'
-ckan_spatial_sha='c35e1249cfb3c7b2f1286f433fd51c6fe8f05b72'
+ckan_spatial_sha='46b706549aaf13a4ef2451d6185d7a90a75aeb0f'
 
 ckan_sha='ckan-2.8.3-dgu'
 

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -156,6 +156,9 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     # IPackageController
 
+    def before_index(self, data_dict):
+        return schema_defs.trim_strings_for_index(data_dict)
+
     def after_show(self, context, data_dict):
         if 'type' in data_dict and data_dict['type'] != 'harvest':
             harvest_object = model.Session.query(HarvestObject) \

--- a/ckanext/datagovuk/schema.py
+++ b/ckanext/datagovuk/schema.py
@@ -1,4 +1,10 @@
+from copy import deepcopy
+from fnmatch import fnmatchcase
 
+from six import iteritems, string_types
+from six.moves import collections_abc
+
+from ckan.common import config
 import ckan.plugins.toolkit as toolkit
 
 EXTRA_KEYS = [
@@ -53,3 +59,64 @@ def user_edit_form_schema():
                        toolkit.get_validator('user_password_validator_dgu'), toolkit.get_validator('user_passwords_match')]
     return schema
 
+# based on known text-type or specifically unindexed fields in schema.xml, specified as
+# fnmatch-style patterns as it allows us to list them with the same wildcards used there.
+_index_long_string_safe_key_patterns = (
+    "title",
+    "notes",
+    "text",
+    "urls",
+    "depends_on",
+    "dependency_of",
+    "derives_from",
+    "has_derivation",
+    "links_to",
+    "linked_from",
+    "child_of",
+    "parent_of",
+    "harvest",
+    "extras_*",
+    "res_extras_*",
+    # specifically unindexed by schema, using indexed="false"
+    "data_dict",
+    "validated_data_dict",
+)
+
+def _fnmatches_any(key, safe_key_patterns):
+    return any(fnmatchcase(key, kp) for kp in safe_key_patterns)
+
+def _trim_strings_for_index_inner(value, limit):
+    if isinstance(value, string_types):
+        return value[:limit]
+    elif isinstance(value, collections_abc.Mapping):
+        return {
+            k: _trim_strings_for_index_inner(v, limit)
+            for k, v in iteritems(value)
+        }
+    elif isinstance(value, collections_abc.Sequence):
+        # already eliminated possibility of this being a string
+        return [_trim_strings_for_index_inner(v, limit) for v in value]
+
+    return value
+
+def trim_strings_for_index(
+    data_dict,
+    safe_key_patterns=_index_long_string_safe_key_patterns,
+):
+    """
+    return a copy of @data_dict, with any string values truncated to a length
+    (determined by config variable `ckan.datagovuk.trim_strings_for_index_default_limit`
+    unless they are under a toplevel key matching one of @safe_key_patterns.
+    """
+    limit = config.get(
+        "ckan.datagovuk.trim_strings_for_index_default_limit",
+        15000,  # approx half solr6's string-field length limit
+    )
+
+    return {
+        k: (
+            deepcopy(v)  # don't modify, but return a clean copy
+            if _fnmatches_any(k, safe_key_patterns) else
+            _trim_strings_for_index_inner(v, limit)  # recurse into, trimming strings
+        ) for k, v in iteritems(data_dict)
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas==0.24.2
 psycopg2==2.7.5
 Shapely>=1.2.13
 sentry-sdk==0.14.4
-six==1.12.0
+six==1.15.0
 xlrd==1.2.0


### PR DESCRIPTION
https://trello.com/c/r2q5qNr8/

Solr6+ limits fields of type `StrField` to a length of ~32k, but ckan's `schema.xml` has a catchall field which will add unmentioned fields as `StrFields`. This means we can only afford to have strings greater than 32k under keys we're pretty sure the schema has `TextFields` for. Take this list of "safe" field name patterns from the `ckan28` schema as @ https://github.com/alphagov/govuk-puppet/blob/a927fcdf8210bfb4f810ca619a0c4df9fcde425a/modules/govuk_solr6/files/ckan28.schema.xml

Also bump `ckanext-spatial` version to that matching `master`.