### PR TITLE
Temporarily prevent Sentry errors from Staging

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -281,7 +281,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     # IMiddleware
 
     def before_send(self, event, hint):
-        return None if [i for i in ['localhost', 'integration'] if i in config.get('ckan.site_url')] \
+        return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] \
             else event
 
     def make_middleware(self, app, config):


### PR DESCRIPTION
## What

Temporarily prevent errors being sent as reindexing could cause a large number of errors as it did on Integration

## Why

The errors caused the rate limit to be hit which meant that other govuk app errors were not visible.