### PR TITLE
Add alert banner to all pages

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -99,6 +99,7 @@ p.home-text {
 
 .home-footer {
   color: #000;
+  background: #ffffff;
 }
 
 h1.home-footer-heading {
@@ -110,3 +111,6 @@ p.home-footer-text {
   line-height: 1.5;
 }
 
+.homepage {
+  background: #128400;
+}

--- a/ckanext/datagovuk/templates/page.html
+++ b/ckanext/datagovuk/templates/page.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block flash %}
+{{ super() }}
+<div class="alert alert-warning">
+  <p>There will be a publishing freeze from 06:30am on 27 August to 11:59pm to 28 August. You won't be able to publish, edit or delete datasets while we upgrade the data publishing tool.</p>
+  <p>There will not be any downtime for visitors – only publishing will be affected.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## What
Adds an alert banner that appears on all pages of ckan with the following message:

> There will be a publishing freeze from 06:30am on 27 August to 11:59pm to 28 August. You won't be able to publish, edit or delete datasets while we upgrade the data publishing tool.
There will not be any downtime for visitors – only publishing will be affected.

This alert banner uses [the bootstrap alert warning component](https://getbootstrap.com/docs/4.0/components/alerts/).

What it looks like:
<img width="985" alt="Screenshot 2020-08-19 at 14 26 34" src="https://user-images.githubusercontent.com/64783893/90649511-b91ab980-e232-11ea-86df-137c90496a4d.png">
<img width="1020" alt="Screenshot 2020-08-19 at 14 26 13" src="https://user-images.githubusercontent.com/64783893/90649527-bcae4080-e232-11ea-838f-239e5a94216c.png">

## Why
This is to alert users that ckan will be down next Thursday (27th August) whilst the DGU upgrade team move ckan from 2.7 to 2.8.

**Card:** https://trello.com/c/0VQ2mvRX/262-add-a-banner-for-advanced-warning-of-downtime