### PR TITLE
re-target at ckan-2.8.5-dgu branch, removing DGUUserRequestResetView

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,7 @@ ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='46b706549aaf13a4ef2451d6185d7a90a75aeb0f'
 
-ckan_sha='ckan-2.8.5-dgu'
+ckan_sha='568bc076ae4d42f8de53a1e3c62f413d17308abf'  # ckan-2.8.5-dgu HEAD at time of commit
 
 pycsw_tag='2.4.0'
 

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -9,7 +9,7 @@ ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='46b706549aaf13a4ef2451d6185d7a90a75aeb0f'
 
-ckan_sha='ckan-2.8.3-dgu'
+ckan_sha='ckan-2.8.5-dgu'
 
 pycsw_tag='2.4.0'
 

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -208,7 +208,6 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         from ckanext.datagovuk.views.user import (
             DGUUserEditView,
             DGUUserRegisterView,
-            DGUUserRequestResetView,
             me,
         )
         bp = Blueprint("datagovuk", self.__module__)
@@ -229,11 +228,6 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         # call it directly instead of redirecting externally
         import ckan.views.user as ckan_user_views
         ckan_user_views.me = me
-
-        bp.add_url_rule(
-            u'/user/reset',
-            view_func=DGUUserRequestResetView.as_view(str(u'request_reset')),
-        )
 
         return bp
 

--- a/ckanext/datagovuk/tests/test_user.py
+++ b/ckanext/datagovuk/tests/test_user.py
@@ -258,11 +258,11 @@ class TestRequestPasswordReset(helpers.FunctionalTestBase, DBTest):
         response = app.post(
             url=url_for("user.request_reset"),
             params={u"user": u"foo@example.com"},
-            status=200,
         )
-
-        self.assertIn("Could not send reset link", response.body)
         self.assertTrue(mock_mail_user.called)
+
+        response = response.follow()
+        self.assertIn("Error sending the email", response.body)
 
 
 class TestPerformPasswordReset(helpers.FunctionalTestBase, DBTest):

--- a/ckanext/datagovuk/views/user.py
+++ b/ckanext/datagovuk/views/user.py
@@ -1,16 +1,11 @@
 from six import text_type
 
 from ckan.common import g
-import ckan.lib.helpers as h
-import ckan.lib.mailer as mailer
-import ckan.logic as logic
-import ckan.model as model
-from ckan.plugins.toolkit import _, redirect_to, abort
+from ckan.plugins.toolkit import redirect_to, abort
 from ckan.views.user import (
     before_request,
     EditView,
     RegisterView,
-    RequestResetView,
 )
 
 from ckanext.datagovuk.schema import user_edit_form_schema
@@ -43,61 +38,6 @@ class DGUUserRegisterView(_UserBeforeRequestMixin, RegisterView):
     """
     def post(self, *args, **kwargs):
         abort(403)
-
-
-class DGUUserRequestResetView(_UserBeforeRequestMixin, RequestResetView):
-    """
-    A RequestResetView that will also allow password to be reset by
-    providing email address, not just username
-    """
-    def post(self):
-        context, data_dict = self._prepare()
-        id = data_dict[u'id']
-
-        context = {u'model': model, u'user': g.user}
-        user_obj = None
-        try:
-            logic.get_action(u'user_show')(context, data_dict)
-            user_obj = context[u'user_obj']
-        except logic.NotFound:
-            # Try getting the user by email
-            user_accounts = model.User.by_email(id)
-            if user_accounts:
-                user_obj = user_accounts[0]
-
-        if not user_obj:
-            # Try searching the user
-            if id and len(id) > 2:
-                user_list = logic.get_action(u'user_list')(context, {
-                    u'id': id
-                })
-                if len(user_list) == 1:
-                    # This is ugly, but we need the user object for the
-                    # mailer,
-                    # and user_list does not return them
-                    data_dict[u'id'] = user_list[0][u'id']
-                    logic.get_action(u'user_show')(context, data_dict)
-                    user_obj = context[u'user_obj']
-                elif len(user_list) > 1:
-                    h.flash_error(_(u'"%s" matched several users') % (id))
-                else:
-                    h.flash_error(_(u'No such user: %s') % id)
-            else:
-                h.flash_error(_(u'No such user: %s') % id)
-
-        if user_obj:
-            try:
-                # FIXME: How about passing user.id instead? Mailer already
-                # uses model and it allow to simplify code above
-                mailer.send_reset_link(user_obj)
-                h.flash_success(
-                    _(u'Please check your inbox for '
-                      u'a reset code.'))
-                return h.redirect_to(u'home.index')
-            except mailer.MailerException as e:
-                h.flash_error(_(u'Could not send reset link: %s') %
-                              text_type(e))
-        return self.get()
 
 
 def me():


### PR DESCRIPTION
https://trello.com/c/zd8HPSDv

Equivalent functionality to `DGUUserRequestResetView`'s is now provided by ckan core. Adapt tests to work with its exact behaviour.