### PR TITLE
Update alert banner to make it clearer

### DIFF
--- a/ckanext/datagovuk/templates/page.html
+++ b/ckanext/datagovuk/templates/page.html
@@ -3,7 +3,7 @@
 {% block flash %}
 {{ super() }}
 <div class="alert alert-warning">
-  <p>There will be a publishing freeze from 06:30am on 27 August to 11:59pm to 28 August. You won't be able to publish, edit or delete datasets while we upgrade the data publishing tool.</p>
-  <p>There will not be any downtime for visitors – only publishing will be affected.</p>
+  <p>There will be a publishing freeze from 06:30am on 27 August to 11:59pm on 28 August.</p>
+  <p>The CKAN publishing tool will not be available. Users can access datasets on <a href="data.gov.uk">data.gov.uk</a> in the normal way during this time.</p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## What

Make it clearer that CKAN is unavailable but data.gov.uk is still working as normal.