### PR TITLE
Temporarily disable sentry during upgrade

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -314,8 +314,10 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     # IMiddleware
 
     def before_send(self, event, hint):
-        return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] \
-            else event
+        # disable sentry while CKAN is processing objects which have timed out due to upgrade
+        return None
+        # return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] \
+        #     else event
 
     def make_middleware(self, app, config):
         # we get this called twice, once for Flask and once for Pylons


### PR DESCRIPTION
## What

Lots of jobs have timed out due to upgrading taking more than 12 hours, so ignore sentry errors for now