### PR TITLE
Remove upgrade alert banner

### DIFF
--- a/ckanext/datagovuk/templates/page.html
+++ b/ckanext/datagovuk/templates/page.html
@@ -1,9 +1,0 @@
-{% ckan_extends %}
-
-{% block flash %}
-{{ super() }}
-<div class="alert alert-warning">
-  <p>There will be a publishing freeze from 06:30am on 27 August to 11:59pm on 28 August.</p>
-  <p>The CKAN publishing tool will not be available. Users can access datasets on <a href="data.gov.uk">data.gov.uk</a> in the normal way during this time.</p>
-</div>
-{% endblock %}


### PR DESCRIPTION
## What

Remove the alert banner now that the CKAN upgrade has finished.

## Reference

https://trello.com/c/Ploo4Bxt/267-considerations-for-28-deployment-to-production