### PR TITLE
Run CI on all agents except 4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ library("govuk")
 
 REPOSITORY = 'ckanext-datagovuk'
 
-node ('(ci-agent-7 || ci-agent-8)') {
+node ('!(ci-agent-4)') {
 
   try {
     stage('Checkout') {


### PR DESCRIPTION
## What

Allow deployment to run on all agents except agent 4.

Avoid agent 4 as it has been reserved for postgres and will fail the tests.