### PR TITLE
Revert "Allow Sentry errors for Staging and Production"

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -316,8 +316,10 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     # IMiddleware
 
     def before_send(self, event, hint):
-        return None if [i for i in ['localhost', 'integration'] if i in config.get('ckan.site_url')] \
-            else event
+        # disable sentry while CKAN is processing objects which have timed out due to upgrade
+        return None
+        # return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] \
+        #     else event
 
     def make_middleware(self, app, config):
         # we get this called twice, once for Flask and once for Pylons


### PR DESCRIPTION
## What

Reverts alphagov/ckanext-datagovuk#496

Errors are coming through as some object IDs cannot be found, this might be due to the data sync.
For now lets revert and investigate the issue, I have grabbed a number of IDs to investigate the issue and will try to find a work around to prevent lots of sentry errors being generated.

