### PR TITLE
Allow sentry errors on production

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -316,10 +316,8 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     # IMiddleware
 
     def before_send(self, event, hint):
-        # disable sentry while CKAN is processing objects which have timed out due to upgrade
-        return None
-        # return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] \
-        #     else event
+        return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] \
+            else event
 
     def make_middleware(self, app, config):
         # we get this called twice, once for Flask and once for Pylons


### PR DESCRIPTION
## What

Just enable sentry on production as Staging is prone to errors where it can't find the harvest object id, this might be due to the overnight data sync. 

Logs on production do not have the error so these sentry errors would not appear.

## Reference 

https://trello.com/c/ssYoWQnK/254-considerations-for-28-deployment-to-staging