### PR TITLE
Revert "Allow sentry errors on production"

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -316,8 +316,10 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     # IMiddleware
 
     def before_send(self, event, hint):
-        return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] \
-            else event
+        # disable sentry while CKAN is processing objects which have timed out due to upgrade
+        return None
+        # return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] \
+        #     else event
 
     def make_middleware(self, app, config):
         # we get this called twice, once for Flask and once for Pylons


### PR DESCRIPTION
## What

Reverts alphagov/ckanext-datagovuk#498

Sentry is being sent lots of errors to do with data issues, so for now revert to not send these kinds of errors and investigate the issue as otherwise the errors will cause Sentry to be rate limited preventing other apps from reporting errors.

## Reference

https://trello.com/c/xLnwdSng/274-investigate-errors-in-sentry-and-prevent-unnecessary-ones-from-being-pushed-up