### PR TITLE
Don't push data errors up to Sentry

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -325,7 +325,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     ]
 
     def before_send(self, event, hint):
-        return None if [i for i in ['localhost', 'integration', 'staging'] if i in config.get('ckan.site_url')] or \
+        return None if [i for i in ['localhost', 'integration'] if i in config.get('ckan.site_url')] or \
             any(s in event['logentry']['message'] for s in self.IGNORED_DATA_ERRORS) \
             else event
 

--- a/ckanext/datagovuk/tests/test_plugin.py
+++ b/ckanext/datagovuk/tests/test_plugin.py
@@ -56,3 +56,26 @@ class TestPlugin(unittest.TestCase):
         assert ('__junk',) in data
         assert ('invalid', 0, 'key') in data[('__junk',)]
         assert ('invalid', 0, 'value') in data[('__junk',)]
+
+    def test_plugin_before_send(self):
+        mock_event  = {
+            'logentry': {
+                'message': 'System error'
+            }
+        }
+        response = DatagovukPlugin().before_send(mock_event, '')
+
+        assert response == mock_event
+
+    def test_plugin_before_send_ignores_data_errors(self):
+        mock_events = [
+            {'logentry': {'message': 'Found more than one dataset with the same guid xxx'}},
+            {'logentry': {'message': 'Errors found for object with GUID xxx'}},
+            {'logentry': {'message': 'Job timeout: xxx is taking longer than yyy minutes'}},
+            {'logentry': {'message': 'Job xxx was aborted or timed out, object yyy set to error'}},
+            {'logentry': {'message': 'Too many consecutive retries for object'}}
+        ]
+
+        for mock_event in mock_events:
+            response = DatagovukPlugin().before_send(mock_event, '')
+            assert not response


### PR DESCRIPTION
## What

Re-enable sentry errors for Staging and Production but as data errors are already reported to publishers, pushing these errors up to Sentry will cause the rate limit to be hit preventing other apps from reporting errors. So prevent them from being sent to Sentry as they are already recorded else where and presented to the publishers.

## Reference 

https://trello.com/c/xLnwdSng/274-investigate-errors-in-sentry-and-prevent-unnecessary-ones-from-being-pushed-up