### PR TITLE
Ignore harvest object does not exist error

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -321,7 +321,8 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "Errors found for object with GUID",                # Spatial
         "Job timeout:",                                     # Harvest
         "was aborted or timed out",                         # Harvest
-        "Too many consecutive retries for object"           # Harvest
+        "Too many consecutive retries for object",          # Harvest
+        "Harvest object does not exist:"                    # Harvest
     ]
 
     def before_send(self, event, hint):

--- a/ckanext/datagovuk/tests/test_plugin.py
+++ b/ckanext/datagovuk/tests/test_plugin.py
@@ -73,7 +73,8 @@ class TestPlugin(unittest.TestCase):
             {'logentry': {'message': 'Errors found for object with GUID xxx'}},
             {'logentry': {'message': 'Job timeout: xxx is taking longer than yyy minutes'}},
             {'logentry': {'message': 'Job xxx was aborted or timed out, object yyy set to error'}},
-            {'logentry': {'message': 'Too many consecutive retries for object'}}
+            {'logentry': {'message': 'Too many consecutive retries for object'}},
+            {'logentry': {'message': 'Harvest object does not exist: xxx'}}
         ]
 
         for mock_event in mock_events:


### PR DESCRIPTION
## What

`Harvest object does not exist` is being sent to Sentry when we can ignore it as its an issue with the data sync between production and staging.