### PR TITLE
Ignore CSW identifier already used: Spatial plugin

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -1,5 +1,6 @@
 import logging
 from pylons import config
+import re
 
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
@@ -319,6 +320,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     IGNORED_DATA_ERRORS = [
         "Found more than one dataset with the same guid",   # DCat
         "Errors found for object with GUID",                # Spatial
+        "CSW identifier '(\w|-)+' already used, skipping",  # Spatial
         "Job timeout:",                                     # Harvest
         "was aborted or timed out",                         # Harvest
         "Too many consecutive retries for object",          # Harvest
@@ -327,7 +329,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     def before_send(self, event, hint):
         return None if [i for i in ['localhost', 'integration'] if i in config.get('ckan.site_url')] or \
-            any(s in event['logentry']['message'] for s in self.IGNORED_DATA_ERRORS) \
+            any(re.search(s, event['logentry']['message']) for s in self.IGNORED_DATA_ERRORS) \
             else event
 
     def make_middleware(self, app, config):

--- a/ckanext/datagovuk/tests/test_plugin.py
+++ b/ckanext/datagovuk/tests/test_plugin.py
@@ -74,7 +74,8 @@ class TestPlugin(unittest.TestCase):
             {'logentry': {'message': 'Job timeout: xxx is taking longer than yyy minutes'}},
             {'logentry': {'message': 'Job xxx was aborted or timed out, object yyy set to error'}},
             {'logentry': {'message': 'Too many consecutive retries for object'}},
-            {'logentry': {'message': 'Harvest object does not exist: xxx'}}
+            {'logentry': {'message': 'Harvest object does not exist: xxx'}},
+            {'logentry': {'message': 'CSW identifier \'xxx-yyy-111-222\' already used, skipping'}},
         ]
 
         for mock_event in mock_events:


### PR DESCRIPTION
## What

Ignore errors where CSW identifier is already used being sent to Sentry as users will already have been informed in their harvest logs and it is more likely a data issue rather than a system error.