### PR TITLE
Handle ascii when filtering query

### DIFF
--- a/ckanext/datagovuk/ckan_patches/query.py
+++ b/ckanext/datagovuk/ckan_patches/query.py
@@ -6,9 +6,16 @@ BLOCK_TAGS = ['{!xmlparser', '<!doctype']
 logger = logging.getLogger(__name__)
 
 
+def safe_str(obj):
+    try:
+        return str(obj)
+    except UnicodeEncodeError:
+        return obj.encode('ascii', 'ignore').decode('ascii')
+
+
 def run(self, *args, **kwargs):
     for k in args[0]:
-        if all(tag in str(args[0][k]).lower() for tag in BLOCK_TAGS):
+        if all(tag in safe_str(args[0][k]).lower() for tag in BLOCK_TAGS):
             logger.warn('DGU search blocked: %r', args[0][k])
             return {"count": 0, "results": []}
 

--- a/ckanext/datagovuk/tests/test_ckan_patches.py
+++ b/ckanext/datagovuk/tests/test_ckan_patches.py
@@ -144,3 +144,23 @@ class TestPackageSearchQuery:
         assert response == {'count': 1, 'results': [{"key": "value"}]}
 
         assert not mock_logger.called
+
+    @patch('ckan.lib.search.query.PackageSearchQuery.original_run',
+        return_value={"count": 1, "results": [{"key": "value"}]})
+    @patch('ckanext.datagovuk.ckan_patches.logger.warn')
+    def test_package_search_run_can_handle_ascii(self, mock_logger, mock_package_search_query):
+        query = ckan.lib.search.query.PackageSearchQuery()
+
+        q = MultiDict(
+            [
+                ('fl', u'{\xa3!xmlparser}'),
+                ('q', u'extras_harvest_source_id:["" TO *]and dataset_type:dataset'),
+                ('fq', '+capacity:public')
+            ]
+        )
+
+        response = query.run(q)
+        assert mock_package_search_query.called
+        assert response == {'count': 1, 'results': [{"key": "value"}]}
+
+        assert not mock_logger.called


### PR DESCRIPTION
## What

Will convert characters to unicode and ignores characters which can't be converted but as the args will be passed on unchanged this shouldn't affect subsequent processing.