### PR TITLE
Remove upload field from new publisher page

### DIFF
--- a/ckanext/datagovuk/templates/organization/snippets/organization_form.html
+++ b/ckanext/datagovuk/templates/organization/snippets/organization_form.html
@@ -25,10 +25,4 @@
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my organization...'), value=data.description, error=errors.description) }}
 
     {{ form.select('category', label=_('Category'), options=h.publisher_category(), selected=data.get('category', ''), error=errors.category, attrs={'class': 'form-control'}) }}
-
-    {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
-    {% set is_url = data.image_url and data.image_url.startswith('http') %}
-
-    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
-
   {% endblock %}


### PR DESCRIPTION
## What
Removes the image upload field from the create publisher and edit publisher views.

## Why
Upon investigation, it was discovered that the uploaded image from this upload field isn't utilised anywhere within ckan. Additionally, it was discovered that these upload fields are a potential security vulnerability and should be removed where possible.

## Visual changes
### Before
![Screenshot 2020-11-16 at 10 51 47](https://user-images.githubusercontent.com/64783893/99250952-74d49080-2804-11eb-84c9-d89d580018c4.png)

### After
![Screenshot 2020-11-16 at 10 51 34](https://user-images.githubusercontent.com/64783893/99250964-7b630800-2804-11eb-8904-d068f80a2c9e.png)

[Card](https://trello.com/c/Kfcpv9g1/280-remove-upload-image-on-publisher)