### PR TITLE
Update styling of active navigation items

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -18,14 +18,11 @@ body {
   background-color: #003647;
 }
 
-.dataset .masthead .navigation .nav-pills li a[href="/dataset"],
-.dataset .masthead .navigation .nav-pills li.active a[href="/dataset"],
-.publisher .masthead .navigation .nav-pills li a[href="/publisher"],
-.publisher .masthead .navigation .nav-pills li.active a[href="/publisher"],
-.harvest .masthead .navigation .nav-pills li a[href="/harvest"],
-.harvest .masthead .navigation .nav-pills li.active a[href="/harvest"],
-.site .masthead .navigation .nav-pills li a[href="/site-usage"],
-.site .masthead .navigation .nav-pills li.active a[href="/site-usage"] {
+.masthead .navigation .nav-pills li.active a,
+.dataset .masthead .navigation .nav-pills li a[href="/dataset/"],
+.publisher .masthead .navigation .nav-pills li a[href="/publisher/"],
+.publisher .masthead .navigation .nav-pills li a[href="/organization/"],
+.harvest .masthead .navigation .nav-pills li a[href="/harvest/"] {
   background-color: rgb(0, 130, 59);
 }
 


### PR DESCRIPTION
## What
Amend the styling of navigation item highlighting. Specifically:

- Add a `/` to the end of the `href` selector on navigation links
- Remove some styles that are no longer necessary

## Why
During the upgrade from 2.8 to 2.9, the links between sections in the ckan UI changed to include a trailing slash on the links. This broke the styling we currently have for links that are specified via the `href`. This feature is useful to communicate to users where they are within the ckan service.

This level of specificity in our CSS is less than ideal, however we aren't in full control of this setup as the navigation is handled within ckan (not this extension).

I removed the additional calls to `li.active a` as I don't envision a situation where we would ever have 2 "active" `li`'s at any one time. We also don't have a site usage page anymore that's accessible from the header navigation so I've removed this as well.

## Additional context
Tests that theoretically aren't effected by this change are failing intermittently here, however this is expected as it's part of an ongoing upgrade on this app from python 2 to python 3 (hence the merging-into branch name). The tests working against python 3 and the test suit set up on python 3 are being handled in a separate stream of work by @kentsanggds.

## Visual changes
### Before
![Screenshot 2020-11-30 at 15 52 54](https://user-images.githubusercontent.com/64783893/100631997-3a024a80-3324-11eb-9be0-77d243598109.png)

### After
![Screenshot 2020-11-30 at 15 53 04](https://user-images.githubusercontent.com/64783893/100632011-3d95d180-3324-11eb-8f00-33daa352bb23.png)
