### PR TITLE
Fix minor visual bug on ckan dashboard

### DIFF
--- a/ckanext/datagovuk/public/datagovuk.css
+++ b/ckanext/datagovuk/public/datagovuk.css
@@ -210,3 +210,7 @@ label.checkbox[for=field-remember] {
 input {
   height: 1.75em;
 }
+
+.activity .item .date {
+  white-space: normal;
+}


### PR DESCRIPTION
## What
Adds an override CSS definition for selector `. activity .item .date` with attribute `white-space: normal`.

## Why
In ckan's default CSS, the above selector's `white-space` attribute is set to `no-wrap`. This results in the `date` section on the ckan dashboard view to act unpredictably on mobile screen sizes, either flowing off the page or resizing the page. This change ensures that the element flows onto the next line, avoiding unnecessary scrolling or visual bugs for the user.

## Visual changes
### Before
![Screenshot 2020-12-16 at 16 26 57](https://user-images.githubusercontent.com/64783893/102377047-23165600-3fbc-11eb-8133-c336907f0a5e.png)

### After
![Screenshot 2020-12-16 at 16 26 19](https://user-images.githubusercontent.com/64783893/102377058-27427380-3fbc-11eb-8521-d9f65fedf30d.png)