### PR TITLE
Update spatial sha to log calls

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -8,7 +8,7 @@ ckan_harvest_sha='d939cd1a7d767af16816310d8d954d33e2b79c7c'
 ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 
 ckan_spatial_fork='alphagov'
-ckan_spatial_sha='46b706549aaf13a4ef2451d6185d7a90a75aeb0f'
+ckan_spatial_sha='01f895f369040fb2d3dae7e6bbb42737cdd456c7'
 
 ckan_sha='ckan-2.8.3-dgu'
 


### PR DESCRIPTION
## What

Use a branch of Spatial https://github.com/alphagov/ckanext-spatial/tree/log-calls which in turn uses a forked repo https://github.com/alphagov/Autologging/tree/only_trace_calls which has been adapted to only trace calls.

As the logging will be temporary it shouldn't be necessary to merge the additional logging into Spatial master. 

The logging has been tested on my local dev stack and it appears to be working.

## Reference 

https://trello.com/c/ayNNNyB2/2329-add-logging-to-trace-calls-in-ckanext-spatial