### PR TITLE
Update spatial sha in install_dependencies

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -8,7 +8,7 @@ ckan_harvest_sha='d939cd1a7d767af16816310d8d954d33e2b79c7c'
 ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 
 ckan_spatial_fork='alphagov'
-ckan_spatial_sha='01f895f369040fb2d3dae7e6bbb42737cdd456c7'
+ckan_spatial_sha='2a78cc968232925acbc53b2315172cecca54f924'
 
 ckan_sha='ckan-2.8.3-dgu'
 


### PR DESCRIPTION
## What

Some classes were producing too much logging and I've identified some other classes which would be useful to trace

The logging has been simplified in the AutoLogging fork used by the spatial extension as it was inflated by the args passed into the functions which can be quite large.

## Reference

https://trello.com/c/ayNNNyB2/2329-add-logging-to-trace-calls-in-ckanext-spatial