### PR TITLE
Add performance platform topics

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ node ('!(ci-agent-4)') {
     stage('Installing Packages') {
       sh("rm -rf ./venv")
       sh("virtualenv --no-site-packages ./venv")
+      sh("curl https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py")
+      sh("bash -c 'venv/bin/python get-pip.py pip==20.3.4'")
       sh("./bin/install-dependencies.sh ./venv/bin/pip")
     }
 

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -16,8 +16,6 @@ pycsw_tag='2.4.0'
 
 pipopt='--exists-action=b'
 
-$pip install $pipopt -U pip
-
 $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_harvest_fork/ckanext-harvest/$ckan_harvest_sha/pip-requirements.txt)
 $pip install $pipopt -U "git+https://github.com/$ckan_harvest_fork/ckanext-harvest.git@$ckan_harvest_sha#egg=ckanext-harvest"
 

--- a/ckanext/datagovuk/helpers.py
+++ b/ckanext/datagovuk/helpers.py
@@ -109,6 +109,8 @@ def themes():
         "education": "Education",
         "health": "Health",
         "transport": "Transport",
+        "digital-services-performance": "Digital services performance",
+        "government-reference-data": "Government reference data"
     }
     return themes_dict
 

--- a/ckanext/datagovuk/tests/test_helpers.py
+++ b/ckanext/datagovuk/tests/test_helpers.py
@@ -57,6 +57,8 @@ class TestHelpers(DBTest):
             "education": "Education",
             "health": "Health",
             "transport": "Transport",
+            "digital-services-performance": "Digital services performance",
+            "government-reference-data": "Government reference data"
         }
         self.assertEqual(h.themes(), themes_dict)
 


### PR DESCRIPTION
## What

Add platform performance topics (themes) so that platform performance datasets can be tagged and easily found in the Find app.

## Reference

https://trello.com/c/NCq4ylTw/2367-3-add-topics-on-dgu-for-performance-platform