### PR TITLE
Update install_dependencies to use latest spatial

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -5,7 +5,7 @@ pip=${1-'/usr/bin/env pip'}
 ckan_harvest_fork='alphagov'
 ckan_harvest_sha='d939cd1a7d767af16816310d8d954d33e2b79c7c'
 
-ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
+ckan_dcat_sha='46b706549aaf13a4ef2451d6185d7a90a75aeb0f'
 
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='2a78cc968232925acbc53b2315172cecca54f924'


### PR DESCRIPTION
## What

Use the latest alphagov spatial sha as we no longer need the additional logging to identify code paths.

