### PR TITLE
Add sql script to update redundant source_types

### DIFF
--- a/migrations/004_resolve_harvest_source_types.sql
+++ b/migrations/004_resolve_harvest_source_types.sql
@@ -1,0 +1,7 @@
+-- before running these commands on the database, dump out the existing records affected in package_extra
+-- run the update commands below and then use the file to reindex with the 
+-- bin/python_scripts/solr_reindex_package_ids.py
+
+UPDATE package_extra SET value = 'gemini-waf' WHERE value = 'waf';
+UPDATE package_extra SET value = 'gemini-single' WHERE value = 'single-doc';
+UPDATE package_extra SET value = 'gemini-csw' WHERE value = 'csw';


### PR DESCRIPTION
## What

Update redundant source_types to allow the harvest sources to harvest data with the correct source type.

## Reference 

https://trello.com/c/AUbPYGVo/2534-update-redundant-harvest-source-types
https://trello.com/c/Y1dgeI2i/1130-dgu-harvesters-have-incorrect-source-type