### PR TITLE
Ignore exceptions during import

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -321,6 +321,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "Found more than one dataset with the same guid",   # DCat
         "Errors found for object with GUID",                # Spatial
         "CSW identifier '(\w|-)+' already used, skipping",  # Spatial
+        "Exception during import:",                         # Spatial
         "Job timeout:",                                     # Harvest
         "was aborted or timed out",                         # Harvest
         "Too many consecutive retries for object",          # Harvest

--- a/ckanext/datagovuk/tests/test_plugin.py
+++ b/ckanext/datagovuk/tests/test_plugin.py
@@ -76,6 +76,18 @@ class TestPlugin(unittest.TestCase):
             {'logentry': {'message': 'Too many consecutive retries for object'}},
             {'logentry': {'message': 'Harvest object does not exist: xxx'}},
             {'logentry': {'message': 'CSW identifier \'xxx-yyy-111-222\' already used, skipping'}},
+            {'logentry': {
+                'message': '''Exception during import: Traceback (most recent call last):
+  File "/data/vhost/ckan/shared/venv/lib/python2.7/site-packages/ckanext/spatial/harvesters/gemini.py", line 74, in import_stage
+    return self.import_gemini_object(harvest_object)
+  File "/data/vhost/ckan/shared/venv/lib/python2.7/site-packages/ckanext/spatial/harvesters/gemini.py", line 110, in import_gemini_object
+    package_dict = self.write_package_from_gemini_string(unicode_gemini_string, harvest_object)
+  File "/data/vhost/ckan/shared/venv/lib/python2.7/site-packages/ckanext/spatial/harvesters/gemini.py", line 177, in write_package_from_gemini_string
+    harvest_object.harvest_source_id
+Exception: Harvest object xxx (https://example.harvest.source/xxx.xml) has a GUID yyy already in use by xxx1 (https:/example1.harvest.source/test.xml) in harvest source zzz
+                '''
+                }
+            }
         ]
 
         for mock_event in mock_events:


### PR DESCRIPTION
## What

The exception is most likely on the publisher end, and they already get error logs about them on their harvest dashboard so we don't need to report it to sentry.

## Reference 

https://trello.com/c/yjZQ0yBk/2557-investigate-and-fix-sentry-errors