### PR TITLE
Only deploy main-2.9 branch to Integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,12 +40,10 @@ node ('!(ci-agent-4)') {
         }
       }
     }
-    else {
-      if (env.BRANCH_NAME == 'main-2.9') {
-        stage('Deploy CKAN 2.9 to Integration') {
-          govuk.deployIntegration('ckan', BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
-        }
-      }
+    else if (env.BRANCH_NAME == 'main-2.9') {
+      stage('Deploy CKAN 2.9 to Integration') {
+        govuk.deployIntegration('ckan', BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
+      }      
     }
   } catch (e) {
     currentBuild.result = 'FAILED'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,12 @@ node ('!(ci-agent-4)') {
           govuk.dockerTagBranch("ckan", env.BRANCH_NAME, env.BUILD_NUMBER)
         }
       }
-
-      stage('Deploy to Integration') {
-        govuk.deployIntegration('ckan', BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
+    }
+    else {
+      if (env.BRANCH_NAME == 'main-2.9') {
+        stage('Deploy CKAN 2.9 to Integration') {
+          govuk.deployIntegration('ckan', BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
+        }
       }
     }
   } catch (e) {


### PR DESCRIPTION
## What

Skip deployments from `main` branch which are CKAN 2.8 releases so that deployments of CKAN 2.9 can be deployed from `main-2.9` branch.

## Reference 

https://trello.com/c/GZP41t9N/2553-deploy-ckan-29-onto-integration