### PR TITLE
Add banner to warn users of downtime next week

### DIFF
--- a/ckanext/datagovuk/templates/page.html
+++ b/ckanext/datagovuk/templates/page.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block flash %}
+{{ super() }}
+<div class="alert alert-warning">
+  <p>There will be a publishing freeze from 06:30am on 6 July to 11:59pm on 7 July.</p>
+  <p>The CKAN publishing tool will not be available. Users can access datasets on <a href="data.gov.uk">data.gov.uk</a> in the normal way during this time.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## What 

Show a banner to publishers to forewarn them about downtime to CKAN due to major upgrade work.

## Reference 

https://trello.com/c/kNnlbSBh/2598-create-banner-and-email-for-scheduled-downtime-for-upgrade