### PR TITLE
Update downtime notice dates

### DIFF
--- a/ckanext/datagovuk/templates/page.html
+++ b/ckanext/datagovuk/templates/page.html
@@ -3,7 +3,7 @@
 {% block flash %}
 {{ super() }}
 <div class="alert alert-warning">
-  <p>There will be a publishing freeze from 06:30am on 6 July to 11:59pm on 7 July.</p>
+  <p>There will be a publishing freeze from 06:30am on 5 August to 11:59pm on 6 August.</p>
   <p>The CKAN publishing tool will not be available. Users can access datasets on <a href="data.gov.uk">data.gov.uk</a> in the normal way during this time.</p>
 </div>
 {% endblock %}


### PR DESCRIPTION
The downtime has been delayed, so we need to update the banner.

[Trello card](https://trello.com/c/4JYtAux6)