### PR TITLE
Update organogram file handling for 2.9

### DIFF
--- a/ckanext/datagovuk/action/create.py
+++ b/ckanext/datagovuk/action/create.py
@@ -33,6 +33,14 @@ class FakeFieldStorage(cgi.FieldStorage):
         self.file = stream
         self.file.seek(0)
 
+    def read(self):
+        self.file.seek(0)
+        return self.file.read()
+
+    def seek(self, pos):
+        self.file.seek(pos)
+
+
 def resource_create(context, data_dict):
     '''Wraps the original CKAN resource creation
     to handle XLS organogram uploads and split them into
@@ -64,9 +72,9 @@ def resource_create(context, data_dict):
         if pkg_dict.get('schema-vocabulary') in organogram_ids:
             log.debug("Organogram detected")
 
-            file_handle = data_dict['upload'].file
+            file_stream = data_dict['upload']
 
-            errors, warnings, senior_csv, junior_csv = create_organogram_csvs(file_handle)
+            errors, warnings, senior_csv, junior_csv = create_organogram_csvs(file_stream)
 
             if errors:
                 context['session'].rollback()

--- a/ckanext/datagovuk/upload.py
+++ b/ckanext/datagovuk/upload.py
@@ -104,7 +104,7 @@ def upload_resource_to_s3(context, resource):
         logger.info("Uploading resource %s to S3" % resource.get('name', ''))
         bucket.Object(s3_filepath).delete()
         obj = bucket.put_object(Key=s3_filepath,
-                                Body=body,
+                                Body=body.getvalue().encode('utf-8'),
                                 ContentType=content_type)
         obj.Acl().put(ACL='public-read')
         logger.info("Successfully uploaded resource %s to S3" % resource.get('name', ''))

--- a/tests/action/test_create.py
+++ b/tests/action/test_create.py
@@ -73,7 +73,7 @@ def mock_data():
     TestWhenValidOrganogramXlsFile.data_dict = {
         "package_id": "1234",
         "url": "valid-organogram.xls",
-        "upload": create.FakeFieldStorage("valid-organogram.xls", open(fixture_path, 'r'))
+        "upload": create.FakeFieldStorage("valid-organogram.xls", open(fixture_path, 'rb'))
     }
 
     TestWhenValidOrganogramXlsFile.pkg_dict = {
@@ -94,7 +94,7 @@ class TestWhenValidOrganogramXlsFile(TestResourceCreate):
     @patch("ckanext.datagovuk.action.create.mimetypes.guess_type")
     @patch("ckanext.datagovuk.action.create.resource_create_core", side_effect=fake_resource_create)
     def test_create_resource_uploads_resource_with_same_timestamp(
-        self, mock_resource_create, mock_guess_type, mock_get_action, mock_upload, mock_data
+        self, mock_resource_create, mock_guess_type, mock_get_action, mock_upload, mock_data, mock_field_storage
     ):
         mock_resource_create.mock_resource_create_list = []
         mock_guess_type.return_value = ['application/vnd.ms-excel']
@@ -172,7 +172,7 @@ class TestWhenValidOrganogramXlsFile(TestResourceCreate):
         self.data_dict = {
             "package_id": "1234",
             "url": "valid-organogram.xls",
-            "upload": create.FakeFieldStorage("valid-organogram.xls", open(self.fixture_path)),
+            "upload": create.FakeFieldStorage("valid-organogram.xls", open(self.fixture_path, 'rb')),
             "datafile-date": "2019-05-23"
         }
 
@@ -226,7 +226,7 @@ def mock_xlsx_data():
     TestWhenValidOrganogramXlsxFile.data_dict = {
         "package_id": "1234",
         "url": "valid-organogram.xls",
-        "upload": create.FakeFieldStorage("valid-organogram.xlsx", open(fixture_path, 'r'))
+        "upload": create.FakeFieldStorage("valid-organogram.xlsx", open(fixture_path, 'rb'))
     }
 
     TestWhenValidOrganogramXlsxFile.pkg_dict = {
@@ -276,7 +276,7 @@ def mock_invalid_senior():
     TestWithInvalidSeniorsInOrganogramExcelFile.data_dict = {
         "package_id": "1234",
         "url": "invalid-organogram.xls",
-        "upload": create.FakeFieldStorage("invalid-organogram.xls", open(fixture_path))
+        "upload": create.FakeFieldStorage("invalid-organogram.xls", open(fixture_path, 'rb'))
     }
 
     TestWithInvalidSeniorsInOrganogramExcelFile.pkg_dict = {
@@ -340,7 +340,7 @@ def mock_invalid_junior():
     TestWithInvalidJuniorsInOrganogramExcelFile.data_dict = {
         "package_id": "1234",
         "url": "invalid-organogram.xls",
-        "upload": create.FakeFieldStorage("invalid-organogram.xls", open(fixture_path))
+        "upload": create.FakeFieldStorage("invalid-organogram.xls", open(fixture_path, 'rb'))
     }
 
     TestWithInvalidJuniorsInOrganogramExcelFile.pkg_dict = {


### PR DESCRIPTION
## What

CKAN 2.9 changed the way it handles uploads, using `werkzeug.datastructures.FileStorage` which is different from how it was on CKAN 2.8. So this PR updates the way it handles the upload and fixes the tests to reflect the change.

## Reference

https://trello.com/c/Ia8weJBu/2612-fix-organograms-on-ckan-29