### PR TITLE
Change SHA for ckanext-harvest

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -3,7 +3,7 @@
 pip=${1-'/usr/bin/env pip'}
 
 ckan_harvest_fork='alphagov'
-ckan_harvest_sha='d939cd1a7d767af16816310d8d954d33e2b79c7c'
+ckan_harvest_sha='ba53566fb51d6d860b2a1c36b46fe9ebe2cf53b3'
 
 ckan_dcat_sha='b757e5be643a17f08b1bb102348c370abee149d5'
 


### PR DESCRIPTION
This [incorporates](https://github.com/ckan/ckanext-harvest/compare/d939cd1a7d767af16816310d8d954d33e2b79c7c...alphagov:ba53566fb51d6d860b2a1c36b46fe9ebe2cf53b3?expand=1) [a bug fix](https://github.com/ckan/ckanext-harvest/issues/420) which stops duplicated harvest objects being added to Redis. We believe this caused Redis to run out of memory.