### PR TITLE
Update Jenkinsfile to use ckan not ckan29

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,12 +36,12 @@ node ('!(ci-agent-4)') {
 
       if (govuk.hasDockerfile()) {
         stage("Tag Docker image") {
-          govuk.dockerTagBranch("ckan29", env.BRANCH_NAME, env.BUILD_NUMBER)
+          govuk.dockerTagBranch("ckan", env.BRANCH_NAME, env.BUILD_NUMBER)
         }
       }
 
       stage('Deploy to Integration') {
-        govuk.deployIntegration('ckan29', BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
+        govuk.deployIntegration('ckan', BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
       }
     }
   } catch (e) {


### PR DESCRIPTION
## What

`ckan29` isn't available for deployment downstream in puppet so use the updated `ckan` app which is now configured to use python 3 instead. This will also fix the problem of the release version check in puppet which would have needed to be reset for `ckan29`.

## Reference 

https://trello.com/c/DZJFi8z5/2613-create-prs-to-prep-for-29-upgrade