### PR TITLE
Remove maintenance banner after upgrade

### DIFF
--- a/ckanext/datagovuk/templates/page.html
+++ b/ckanext/datagovuk/templates/page.html
@@ -1,9 +1,0 @@
-{% ckan_extends %}
-
-{% block flash %}
-{{ super() }}
-<div class="alert alert-warning">
-  <p>There will be a publishing freeze from 06:30am on 5 August to 11:59pm on 6 August.</p>
-  <p>The CKAN publishing tool will not be available. Users can access datasets on <a href="data.gov.uk">data.gov.uk</a> in the normal way during this time.</p>
-</div>
-{% endblock %}


### PR DESCRIPTION
## What 

After the upgrade we no longer need the maintenance banner so remove it.

## Reference 

https://trello.com/c/7HPu6jyN/2647-deployment-of-ckan-29-steps