### PR TITLE
Enable sentry errors

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -293,12 +293,9 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     ]
 
     def before_send(self, event, hint):
-        # disable sentry while CKAN is processing objects which have timed out due to upgrade
-        return None
-
-        # return None if [i for i in ['localhost', 'integration'] if i in config.get('ckan.site_url')] or \
-        #     any(re.search(s, event['logentry']['message']) for s in self.IGNORED_DATA_ERRORS) \
-        #     else event
+        return None if [i for i in ['localhost', 'integration'] if i in config.get('ckan.site_url')] or \
+            any(re.search(s, event['logentry']['message']) for s in self.IGNORED_DATA_ERRORS) \
+            else event
 
     def make_middleware(self, app, config):
         sentry_sdk.init(before_send=self.before_send, integrations=[FlaskIntegration()])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -58,7 +58,6 @@ class TestPlugin:
         assert ('invalid', 0, 'key') in data[('__junk',)]
         assert ('invalid', 0, 'value') in data[('__junk',)]
 
-    @pytest.mark.skip("Sentry errors disabled during upgrade - enable this test after upgrade complete")
     def test_plugin_before_send(self):
         mock_event  = {
             'logentry': {


### PR DESCRIPTION
## What 

Re-enable sentry errors after CKAN 2.9 upgrade 

## Reference 

https://trello.com/c/7HPu6jyN/2647-deployment-of-ckan-29-steps