### PR TITLE
Update harvest sha fix run test

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -21,6 +21,9 @@ $pip install $pipopt -U numpy==1.16.4
 
 $pip uninstall $pipopt -y enum34
 
+# needed for harvester run-test to targest harvest sources
+$pip install $pipopt -U factory-boy==2.12.0 mock==2.0.0 pytest==4.6.5
+
 $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/ckan/ckan/$ckan_sha/requirement-setuptools.txt)
 $pip install $pipopt -r https://raw.githubusercontent.com/ckan/ckan/$ckan_sha/requirements.txt
 $pip install $pipopt -Ue "git+https://github.com/ckan/ckan.git@$ckan_sha#egg=ckan"

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -21,7 +21,7 @@ $pip install $pipopt -U numpy==1.16.4
 
 $pip uninstall $pipopt -y enum34
 
-# needed for harvester run-test to targest harvest sources
+# needed for harvester run-test to target harvest sources
 $pip install $pipopt -U factory-boy==2.12.0 mock==2.0.0 pytest==4.6.5
 
 $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/ckan/ckan/$ckan_sha/requirement-setuptools.txt)

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -3,7 +3,7 @@
 pip=${1-'/usr/bin/env pip'}
 
 ckan_harvest_fork='alphagov'
-ckan_harvest_sha='ba53566fb51d6d860b2a1c36b46fe9ebe2cf53b3'
+ckan_harvest_sha='6ac2103d5420ecad7eb7cd8a32cdb96a95c7d821'
 
 ckan_dcat_sha='6b7ec505f303fb18e0eebcebf67130d36b3dca82'
 

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -11,7 +11,7 @@ ckan_spatial_fork='alphagov'
 ckan_spatial_sha='7636ed76a168f59ab8ad1e02b435e2ed1fd5732c'
 
 # ckan 2.9.3
-ckan_sha='65a035890428ae581648696871a3021b7ca0f2f4'
+ckan_sha='e8b7970423e2cce9731441edd13f7fcfd3be58e9'
 
 pycsw_tag='2.4.0'
 
@@ -21,9 +21,9 @@ $pip install $pipopt -U numpy==1.16.4
 
 $pip uninstall $pipopt -y enum34
 
-$pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/alphagov/ckan/$ckan_sha/requirement-setuptools.txt)
-$pip install $pipopt -r https://raw.githubusercontent.com/alphagov/ckan/$ckan_sha/requirements.txt
-$pip install $pipopt -Ue "git+https://github.com/alphagov/ckan.git@$ckan_sha#egg=ckan"
+$pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/ckan/ckan/$ckan_sha/requirement-setuptools.txt)
+$pip install $pipopt -r https://raw.githubusercontent.com/ckan/ckan/$ckan_sha/requirements.txt
+$pip install $pipopt -Ue "git+https://github.com/ckan/ckan.git@$ckan_sha#egg=ckan"
 
 $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_harvest_fork/ckanext-harvest/$ckan_harvest_sha/pip-requirements.txt)
 $pip install $pipopt -U "git+https://github.com/$ckan_harvest_fork/ckanext-harvest.git@$ckan_harvest_sha#egg=ckanext-harvest"


### PR DESCRIPTION
## What

Update the harvest sha to fix harvester `run-test` command and also update dependencies to ensure that `run-test` has the dependencies it needs to run.

The CKAN sha has also been updated to use the CKAN master branch rather than a fork of CKAN now that the database has been updated.

This has been tested on Integration.

## Reference 

https://trello.com/c/7HPu6jyN/2647-deployment-of-ckan-29-steps