### PR TITLE
Update sentry errors to ignore

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -290,6 +290,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "was aborted or timed out",                                 # Harvest
         "Too many consecutive retries for object",                  # Harvest
         "Harvest object does not exist:",                           # Harvest
+        "is not a valid format",                                    # Harvest
         "Errors found by ETL were not picked up by spreadsheet",    # Datagovuk
     ]
 

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -282,14 +282,15 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
 
     # Ignore these data errors on sentry as these would already be reported to publishers to resolve or raise
     IGNORED_DATA_ERRORS = [
-        "Found more than one dataset with the same guid",   # DCat
-        "Errors found for object with GUID",                # Spatial
-        "CSW identifier '(\w|-)+' already used, skipping",  # Spatial
-        "Exception during import:",                         # Spatial
-        "Job timeout:",                                     # Harvest
-        "was aborted or timed out",                         # Harvest
-        "Too many consecutive retries for object",          # Harvest
-        "Harvest object does not exist:"                    # Harvest
+        "Found more than one dataset with the same guid",           # DCat
+        "Errors found for object with GUID",                        # Spatial
+        "CSW identifier '(\w|-)+' already used, skipping",          # Spatial
+        "Exception during import:",                                 # Spatial
+        "Job timeout:",                                             # Harvest
+        "was aborted or timed out",                                 # Harvest
+        "Too many consecutive retries for object",                  # Harvest
+        "Harvest object does not exist:",                           # Harvest
+        "Errors found by ETL were not picked up by spreadsheet",    # Datagovuk
     ]
 
     def before_send(self, event, hint):

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -291,6 +291,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "Too many consecutive retries for object",                  # Harvest
         "Harvest object does not exist:",                           # Harvest
         "is not a valid format",                                    # Harvest
+        "Gather stage failed",                                      # Harvest
         "Errors found by ETL were not picked up by spreadsheet",    # Datagovuk
     ]
 

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -293,6 +293,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "is not a valid format",                                    # Harvest
         "Gather stage failed",                                      # Harvest
         "Errors found by ETL were not picked up by spreadsheet",    # Datagovuk
+        "User not found",                                           # CKAN
     ]
 
     def before_send(self, event, hint):

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -284,7 +284,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     IGNORED_DATA_ERRORS = [
         "Found more than one dataset with the same guid",           # DCat
         "Errors found for object with GUID",                        # Spatial
-        "CSW identifier '(\w|-)+' already used, skipping",          # Spatial
+        "CSW identifier '\{?(\w|-)+\}?' already used, skipping",    # Spatial
         "Exception during import:",                                 # Spatial
         "Job timeout:",                                             # Harvest
         "was aborted or timed out",                                 # Harvest

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -76,6 +76,7 @@ class TestPlugin:
             {'logentry': {'message': 'Job xxx was aborted or timed out, object yyy set to error'}},
             {'logentry': {'message': 'Too many consecutive retries for object'}},
             {'logentry': {'message': 'Harvest object does not exist: xxx'}},
+            {'logentry': {'message': 'Gather stage failed'}},
             {'logentry': {
                 'message': "None - {'author_email': ['Email example@test.uk  is not a valid "
                 "format'], 'maintainer_email': ['Email example2@test.uk  is not a valid format']}"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -88,7 +88,16 @@ class TestPlugin:
 Exception: Harvest object xxx (https://example.harvest.source/xxx.xml) has a GUID yyy already in use by xxx1 (https:/example1.harvest.source/test.xml) in harvest source zzz
                 '''
                 }
-            }
+            },
+            {
+                'logentry': {
+                    'message': 'Errors found by ETL were not picked up by spreadsheet: ["Sheet \"(final data) '
+                    'senior-staff\" cell E11: The \"Job/Team Function\" can only be \"N/A\" if the \"Post Unique '
+                    'Reference\" is \"0\" (individual is paid but not in post).","Sheet \"(final data) senior-staff\" '
+                    'cell H11: The \"Unit\" can only be \"N/A\" if the \"Post Unique Reference\" is \"0\" '
+                    '(individual is paid but not in post)."]'
+                }
+            },
         ]
 
         for mock_event in mock_events:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -77,6 +77,7 @@ class TestPlugin:
             {'logentry': {'message': 'Too many consecutive retries for object'}},
             {'logentry': {'message': 'Harvest object does not exist: xxx'}},
             {'logentry': {'message': 'CSW identifier \'xxx-yyy-111-222\' already used, skipping'}},
+            {'logentry': {'message': 'CSW identifier \'{xxx-yyy-111-222}\' already used, skipping'}},
             {'logentry': {
                 'message': '''Exception during import: Traceback (most recent call last):
   File "/data/vhost/ckan/shared/venv/lib/python2.7/site-packages/ckanext/spatial/harvesters/gemini.py", line 74, in import_stage

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -76,6 +76,11 @@ class TestPlugin:
             {'logentry': {'message': 'Job xxx was aborted or timed out, object yyy set to error'}},
             {'logentry': {'message': 'Too many consecutive retries for object'}},
             {'logentry': {'message': 'Harvest object does not exist: xxx'}},
+            {'logentry': {
+                'message': "None - {'author_email': ['Email example@test.uk  is not a valid "
+                "format'], 'maintainer_email': ['Email example2@test.uk  is not a valid format']}"
+                }
+            },
             {'logentry': {'message': 'CSW identifier \'xxx-yyy-111-222\' already used, skipping'}},
             {'logentry': {'message': 'CSW identifier \'{xxx-yyy-111-222}\' already used, skipping'}},
             {'logentry': {

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -105,6 +105,7 @@ Exception: Harvest object xxx (https://example.harvest.source/xxx.xml) has a GUI
                     '(individual is paid but not in post)."]'
                 }
             },
+            {'logentry': {'message': '404 Not Found: User not found'}},
         ]
 
         for mock_event in mock_events:


### PR DESCRIPTION
## What

Add some more errors which are sent to Sentry which can be ignored as they are due to user data which they are aware of or because of a valid error thrown when a user not found.

## Reference 

https://trello.com/c/EyKpnr3E/2666-ignore-post-ckan-upgrade-sentry-errors