### PR TITLE
Only allow organogram xls

### DIFF
--- a/tests/test_s3_resources_plugin.py
+++ b/tests/test_s3_resources_plugin.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 import unittest
 from mock import patch
+import pytest
 
 from ckanext.datagovuk.plugin import DatagovukPlugin
-from nose.tools import assert_raises
+from ckan.plugins.toolkit import ValidationError
 
 
 class TestS3ResourcesPlugin:
     plugin = DatagovukPlugin()
 
     def test_s3_config_exception(self):
-        with assert_raises(KeyError) as context:
+        with pytest.raises(KeyError) as context:
             self.plugin.before_create_or_update({}, {"upload": "dummy value"})
-        assert str(context.exception) == "'Required S3 config options missing'"
+        assert str(context.value) == "'Required S3 config options missing'"
 
     @patch("ckanext.datagovuk.plugin.upload.config_exists")
     def test_upload_early_abort(self, mock_check_config):
@@ -39,3 +40,4 @@ class TestS3ResourcesPlugin:
 
         self.plugin.before_create_or_update({}, resource)
         assert not mock_check_config.called
+

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -9,7 +9,6 @@ from botocore.exceptions import ClientError
 from ckanext.datagovuk.plugin import DatagovukPlugin
 from ckanext.datagovuk.upload import upload_resource_to_s3
 from mock import Mock, patch
-from nose.tools import assert_raises
 
 
 class MockAction:
@@ -75,6 +74,6 @@ class TestUpload:
 
         resource = self.resource.copy()
 
-        with assert_raises(ClientError):
+        with pytest.raises(ClientError):
             upload_resource_to_s3({}, resource)
         assert config.get("ckan.datagovuk.s3_url_prefix") not in resource["url"]


### PR DESCRIPTION
## What

Only allow publishers to upload XLS files, this should help reduce problems with Organogram CSV files.

## Reference 

https://trello.com/c/UGpKiiOb/2673-some-organograms-dont-render-their-interactive-diagrams