### PR TITLE
Ignore more errors sent to sentry

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -294,6 +294,10 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "Gather stage failed",                                      # Harvest
         "Errors found by ETL were not picked up by spreadsheet",    # Datagovuk
         "User not found",                                           # CKAN
+        "not authorised to",                                        # CKAN
+        "Action resource_create requires an authenticated user",    # CKAN
+        "Not Found: The requested URL was not found on the server.",# CKAN
+        "401 Unauthorized: Not authorised to see this page",        # CKAN
     ]
 
     def before_send(self, event, hint):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -77,6 +77,15 @@ class TestPlugin:
             {'logentry': {'message': 'Too many consecutive retries for object'}},
             {'logentry': {'message': 'Harvest object does not exist: xxx'}},
             {'logentry': {'message': 'Gather stage failed'}},
+            {'logentry': {'message': 'User  not authorised to create packages'}},
+            {'logentry': {'message': 'User  not authorised to read resource xxx'}},
+            {'logentry': {'message': 'User  not authorised to read package xxx'}},
+            {'logentry': {'message': 'Action resource_create requires an authenticated user'}},
+            {'logentry': {'message': '401 Unauthorized: Not authorised to see this page'}},
+            {'logentry': {'message': 
+                '404 Not Found: The requested URL was not found on the server. If you entered the URL '
+                'manually please check your spelling and try again.'}
+            },
             {'logentry': {
                 'message': "None - {'author_email': ['Email example@test.uk  is not a valid "
                 "format'], 'maintainer_email': ['Email example2@test.uk  is not a valid format']}"


### PR DESCRIPTION
## What

Ignore auth errors as they are not problems which can be fixed in the code and create noise in sentry which might hide errors which need attention.

## Reference 

https://trello.com/c/bizUat3o/2669-ignore-outstanding-dgu-sentry-errors-based-on-sentry-error-list
