### PR TITLE
Ignore Validation errors from already registered emails

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -298,6 +298,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "Action resource_create requires an authenticated user",    # CKAN
         "Not Found: The requested URL was not found on the server.",# CKAN
         "401 Unauthorized: Not authorised to see this page",        # CKAN
+        "The email address '.+' belongs to a registered user.",     # CKAN
     ]
 
     def before_send(self, event, hint):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -86,6 +86,7 @@ class TestPlugin:
                 '404 Not Found: The requested URL was not found on the server. If you entered the URL '
                 'manually please check your spelling and try again.'}
             },
+            {'logentry': {'message': 'The email address \'test@example.gov\' belongs to a registered user.'}},
             {'logentry': {
                 'message': "None - {'author_email': ['Email example@test.uk  is not a valid "
                 "format'], 'maintainer_email': ['Email example2@test.uk  is not a valid format']}"


### PR DESCRIPTION
## What

Stop validation errors from emails reaching sentry as the error is already visible to users and its not a code bug.

## Reference 

https://trello.com/c/bizUat3o/2669-ignore-outstanding-dgu-sentry-errors-based-on-sentry-error-list