### PR TITLE
Fix deployment of other ckan extensions

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -15,9 +15,9 @@ ckan_sha='e8b7970423e2cce9731441edd13f7fcfd3be58e9'
 
 pycsw_tag='2.4.0'
 
-pipopt='--exists-action=b'
+pipopt='--exists-action=b --force-reinstall'
 
-$pip install $pipopt -U numpy==1.16.4
+$pip install $pipopt -U numpy==1.16.4 wheel==0.37.0
 
 $pip uninstall $pipopt -y enum34
 

--- a/ckanext/datagovuk/upload.py
+++ b/ckanext/datagovuk/upload.py
@@ -77,7 +77,7 @@ def upload_resource_to_s3(context, resource):
     filename = (
         resource.get("timestamp", timestamp.strftime("%Y-%m-%dT%H-%M-%SZ"))
         + "-"
-        + slugify(resource.get("name"), to_lower=True)
+        + slugify(resource.get("name"), lowercase=True)
         + extension
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-awesome-slugify==1.6.5
 beautifulsoup4==4.9.3
 blinker==1.4
 boto3==1.18.34
@@ -7,6 +6,7 @@ lxml>=2.3
 numpy==1.16.4
 psycopg2==2.8.6
 pandas==1.1.4
+python-slugify==5.0.2
 Shapely>=1.2.13
 sentry-sdk==0.17.6
 six==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 awesome-slugify==1.6.5
 beautifulsoup4==4.9.3
 blinker==1.4
-boto3==1.15.1
+boto3==1.18.34
 gunicorn
 lxml>=2.3
 numpy==1.16.4
@@ -10,4 +10,5 @@ pandas==1.1.4
 Shapely>=1.2.13
 sentry-sdk==0.17.6
 six==1.15.0
+sqlalchemy==1.3.5
 xlrd==1.2.0


### PR DESCRIPTION
## What 

Updating the commit sha of ckan extensions besides the datagovuk extension doesn't update the extension properly, so instead force a reinstall which does work. 

## Reference 

https://trello.com/c/wzsJ3luK/2694-fix-upgrade-of-ckan-extensions-during-deployment