### PR TITLE
Ignore group 404 as DGU has organizations

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -294,6 +294,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "Gather stage failed",                                      # Harvest
         "Errors found by ETL were not picked up by spreadsheet",    # Datagovuk
         "User not found",                                           # CKAN
+        "Group not found",                                          # CKAN
         "not authorised to",                                        # CKAN
         "Action resource_create requires an authenticated user",    # CKAN
         "Not Found: The requested URL was not found on the server.",# CKAN

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -77,6 +77,7 @@ class TestPlugin:
             {'logentry': {'message': 'Too many consecutive retries for object'}},
             {'logentry': {'message': 'Harvest object does not exist: xxx'}},
             {'logentry': {'message': 'Gather stage failed'}},
+            {'logentry': {'message': '404 Not Found: Group not found'}},
             {'logentry': {'message': 'User  not authorised to create packages'}},
             {'logentry': {'message': 'User  not authorised to read resource xxx'}},
             {'logentry': {'message': 'User  not authorised to read package xxx'}},


### PR DESCRIPTION
## What

Ignore Group not found errors, we use organizations rather than groups so there would never be any groups to show.

