### PR TITLE
Make sure enum34 is uninstalled

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -20,7 +20,7 @@ pipopt='--exists-action=b --force-reinstall'
 
 $pip install $pipopt -U numpy==1.16.4 wheel==0.37.0
 
-$pip uninstall $pipopt -y enum34
+$pip uninstall -y enum34
 
 # needed for harvester run-test to target harvest sources
 $pip install $pipopt -U factory-boy==2.12.0 mock==2.0.0 pytest==4.6.5


### PR DESCRIPTION
## What

Explicitly remove enum34 before installing ckan as it causes problems with the ckan installation.