### PR TITLE
Fix resources which were using datastore settings

### DIFF
--- a/migrations/005_update_resource_extras.sql
+++ b/migrations/005_update_resource_extras.sql
@@ -1,4 +1,4 @@
 UPDATE resource 
 SET extras = '{"datafile-date": "", "resource-type": "data-link"}',
 last_modified = '2021-09-08' where id IN
-(SELECT id FROM resource WERE state = 'active' AND extras LIKE '%filename%');
+(SELECT id FROM resource WHERE state = 'active' AND extras LIKE '%filename%');

--- a/migrations/005_update_resource_extras.sql
+++ b/migrations/005_update_resource_extras.sql
@@ -1,0 +1,4 @@
+UPDATE resource 
+SET extras = '{"datafile-date": "", "resource-type": "data-link"}',
+last_modified = '2021-09-08' where id IN
+(SELECT id FROM resource WERE state = 'active' AND extras LIKE '%filename%');


### PR DESCRIPTION
## What

Some legacy resources were using datastore which we is not supported in the current running version of CKAN on DGU and is causing errors in CKAN as the datastore extension is not available. In order to get the resources to be viewable the resource extras field need to be updated and the datasets affected need to be reindexed. 

Both of these need to be run manually on the database and on the CKAN machine. 
This has been tested on Integration.

## Reference 

https://trello.com/c/tJdgAiao/2696-investigate-cause-of-build-errors-in-dgu-sentry
