### PR TITLE
Ignore 404 dataset

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -11,7 +11,7 @@ ckan_spatial_fork='alphagov'
 ckan_spatial_sha='3f423de1e9e4e6975725712626d904887779b408'
 
 # ckan 2.9.3 - with dgu fixes
-ckan_sha='aa83bb94b869ef9b15d5bb4a7789e5fa7d9130d2'
+ckan_sha='bc7ed57aba16f755adb39a9b38d04d543a4f4be1'
 ckan_fork='alphagov'
 
 pycsw_tag='2.4.0'

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -298,6 +298,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "not authorised to",                                        # CKAN
         "Action resource_create requires an authenticated user",    # CKAN
         "Not Found: The requested URL was not found on the server.",# CKAN
+        "404 Not Found: Dataset not found",                         # CKAN
         "401 Unauthorized: Not authorised to see this page",        # CKAN
         "The email address '.+' belongs to a registered user.",     # CKAN
     ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -81,6 +81,7 @@ class TestPlugin:
             {'logentry': {'message': 'User  not authorised to create packages'}},
             {'logentry': {'message': 'User  not authorised to read resource xxx'}},
             {'logentry': {'message': 'User  not authorised to read package xxx'}},
+            {'logentry': {'message': '404 Not Found: Dataset not found'}},
             {'logentry': {'message': 'Action resource_create requires an authenticated user'}},
             {'logentry': {'message': '401 Unauthorized: Not authorised to see this page'}},
             {'logentry': {'message': 


### PR DESCRIPTION
## What

After looking at some logs which detailed the user which was trying to access the datasets it is clear that the dataset is not accessible by the user because it has been deleted. Which is why initially there is a user permissions error as sysadmins can still view the dataset but other users will get a 404 response.

So it is safe to ignore the error in Sentry,

## Reference 

https://trello.com/c/De5AG7yb/2703-investigate-cause-of-user-permissions-errors-on-datasets-reads