### PR TITLE
Prevent 404 on resource being sent to Sentry

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -299,6 +299,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "Action resource_create requires an authenticated user",    # CKAN
         "Not Found: The requested URL was not found on the server.",# CKAN
         "404 Not Found: Dataset not found",                         # CKAN
+        "404 Not Found: Resource not found",                        # CKAN
         "401 Unauthorized: Not authorised to see this page",        # CKAN
         "The email address '.+' belongs to a registered user.",     # CKAN
     ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -82,6 +82,7 @@ class TestPlugin:
             {'logentry': {'message': 'User  not authorised to read resource xxx'}},
             {'logentry': {'message': 'User  not authorised to read package xxx'}},
             {'logentry': {'message': '404 Not Found: Dataset not found'}},
+            {'logentry': {'message': '404 Not Found: Resource not found'}},
             {'logentry': {'message': 'Action resource_create requires an authenticated user'}},
             {'logentry': {'message': '401 Unauthorized: Not authorised to see this page'}},
             {'logentry': {'message': 


### PR DESCRIPTION
## What

404s are occurring for some resources because they are in a deleted state so do not send them to sentry as it is not a problem with code.

This is similar to how 404s for deleted datasets are being handled.