### PR TITLE
Update harvest sha to fix redis errors

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -3,7 +3,7 @@
 pip=${1-'/usr/bin/env pip'}
 
 ckan_harvest_fork='alphagov'
-ckan_harvest_sha='d34667413128d6c24168663dea773d1b1c0439da'
+ckan_harvest_sha='f52605c9a4f8ccaa0f5e83937c59ce9bf58cbc06'
 
 ckan_dcat_sha='6b7ec505f303fb18e0eebcebf67130d36b3dca82'
 


### PR DESCRIPTION
## What

The harvest sha linked to ignores redis items with an empty body as this was causing an exception when trying to set it in Redis.

This is the commit linked to - 

https://github.com/alphagov/ckanext-harvest/commit/f52605c9a4f8ccaa0f5e83937c59ce9bf58cbc06

## Reference 

https://trello.com/c/tlYrmfIV/2695-investigate-cause-of-redis-errors-appearing-in-dgu-sentry