### PR TITLE
Fix users password reset by relaxing the username schema

### DIFF
--- a/ckanext/datagovuk/ckan_patches/cli.py
+++ b/ckanext/datagovuk/ckan_patches/cli.py
@@ -16,3 +16,5 @@ def set_password(ctx, username):
 
     _user = model.User.get(username)
     send_password_alert(_user)
+
+ckan.cli.user.set_password = set_password

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -294,6 +294,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "is not a valid format",                                    # Harvest
         "Gather stage failed",                                      # Harvest
         "Errors found by ETL were not picked up by spreadsheet",    # Datagovuk
+        "Organogram template XLS file expected but got:",           # Datagovuk
         "User not found",                                           # CKAN
         "Group not found",                                          # CKAN
         "not authorised to",                                        # CKAN

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -220,6 +220,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
             DGUUserRegisterView,
             me,
         )
+        from ckanext.datagovuk.schema import user_new_form_schema, user_edit_form_schema
 
         bp = Blueprint("datagovuk", self.__module__)
         bp.template_folder = u'templates'
@@ -239,11 +240,6 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         bp.add_url_rule('/publisher', view_func=organization_index, strict_slashes=False)
         bp.add_url_rule('/publisher/new', view_func=organization_index, strict_slashes=False)
 
-        # monkeypatch set_password
-        import ckan.cli.user
-        from ckanext.datagovuk.ckan_patches.cli import set_password
-        ckan.cli.user.set_password = set_password
-
         bp.add_url_rule(
             u"/user/register",
             view_func=DGUUserRegisterView.as_view(str(u'register')),
@@ -257,9 +253,14 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         # also monkeypatch occurrence in original module as some views
         # call it directly instead of redirecting externally
         import ckan.views.user as ckan_user_views
+        ckan_user_views._edit_form_to_db_schema = user_edit_form_schema
+        ckan_user_views._new_form_to_db_schema = user_new_form_schema
         ckan_user_views.me = me
 
         return bp
+
+    # import these for monkey patching
+    from ckanext.datagovuk.ckan_patches import cli, logic, query
 
     # ITemplateHelpers
 

--- a/ckanext/datagovuk/upload.py
+++ b/ckanext/datagovuk/upload.py
@@ -77,7 +77,7 @@ def upload_resource_to_s3(context, resource):
     filename = (
         resource.get("timestamp", timestamp.strftime("%Y-%m-%dT%H-%M-%SZ"))
         + "-"
-        + slugify(resource.get("name"), lowercase=True)
+        + slugify(resource.get("name")).lower()
         + extension
     )
 

--- a/tests/test_ckan_patches.py
+++ b/tests/test_ckan_patches.py
@@ -39,3 +39,14 @@ def test_setpass_sends_email_alert_to_user(mock_mailer, cli):
     assert args[0].email == user_dict['email']
     assert args[1] == 'Your data.gov.uk publisher password has changed'
     assert args[2] == "Your password has been changed, if you haven't done it yourself, let us know"
+
+
+@pytest.mark.ckan_config('ckan.plugins', 'datagovuk')
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+def test_add_username_uses_relaxed_schema(cli):
+    from click.testing import CliRunner
+    from ckan.cli.cli import ckan
+    response = cli.invoke(ckan, ['user', 'add', '"Test User"', 'email=test@example.com'], input="testpass\ntestpass\n")
+
+    assert response.exit_code == 0
+    assert 'Successfully created user: "Test User"' in response.output

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -117,6 +117,7 @@ Exception: Harvest object xxx (https://example.harvest.source/xxx.xml) has a GUI
                     '(individual is paid but not in post)."]'
                 }
             },
+            {'logentry': {'message': 'Organogram template XLS file expected but got: : Organogram to upload - org.csv'}},
             {'logentry': {'message': '404 Not Found: User not found'}},
         ]
 


### PR DESCRIPTION
## What

Users are unable to change their passwords because their Usernames are not valid when using the default CKAN user schema, so relax the user schema by monkey patching it.

Also prevent organogram errors from reaching sentry as its an error that can be handled by the user and fix a bug in making the organogram filenames lowercase.

## Reference 

https://trello.com/c/alHbD02j/2705-users-cannot-change-their-ckan-password