### PR TITLE
Update DCat sha and re-order installation of dependencies

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -36,14 +36,14 @@ $pip install $pipopt -U "git+https://github.com/$ckan_harvest_fork/ckanext-harve
 $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_dcat_fork/ckanext-dcat/$ckan_dcat_sha/requirements.txt)
 $pip install $pipopt -U "git+https://github.com/$ckan_dcat_fork/ckanext-dcat.git@$ckan_dcat_sha#egg=ckanext-dcat"
 
-$pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_spatial_fork/ckanext-spatial/$ckan_spatial_sha/pip-requirements.txt)
-$pip install $pipopt -U "git+https://github.com/$ckan_spatial_fork/ckanext-spatial.git@$ckan_spatial_sha#egg=ckanext-spatial"
-
-$pip install $pipopt -r requirements.txt
-
 $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/geopython/pycsw.git/$pycsw_tag/requirements.txt)
 $pip install $pipopt -Ue "git+https://github.com/geopython/pycsw.git@$pycsw_tag#egg=pycsw"
 
 pycsw_src="$(/usr/bin/env python -m site | grep pycsw | sed "s:[ |,|']::g")"
 (cd $pycsw_src && /usr/bin/env python setup.py build)
 $pip install $pipopt -e .
+
+$pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_spatial_fork/ckanext-spatial/$ckan_spatial_sha/pip-requirements.txt)
+$pip install $pipopt -U "git+https://github.com/$ckan_spatial_fork/ckanext-spatial.git@$ckan_spatial_sha#egg=ckanext-spatial"
+
+$pip install $pipopt -r requirements.txt


### PR DESCRIPTION
## What

OWSLib 0.25.0 was being installed by pycsw which was causing problems for the spatial extension harvesting CSW endpoints. Re-arranging the order of imports will ensure that the spatial extension will install the correct OWSLib version that it needs.

There were also a number of build issues for DCat which I've had to fork to address an issue with the rdflib-jsonld dependency.