### PR TITLE
Ignore 404 harvest jobs as due to dev work

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -291,6 +291,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         "was aborted or timed out",                                 # Harvest
         "Too many consecutive retries for object",                  # Harvest
         "Harvest object does not exist:",                           # Harvest
+        "Harvest job does not exist:",                              # Harvest
         "is not a valid format",                                    # Harvest
         "Gather stage failed",                                      # Harvest
         "Errors found by ETL were not picked up by spreadsheet",    # Datagovuk

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -76,6 +76,7 @@ class TestPlugin:
             {'logentry': {'message': 'Job xxx was aborted or timed out, object yyy set to error'}},
             {'logentry': {'message': 'Too many consecutive retries for object'}},
             {'logentry': {'message': 'Harvest object does not exist: xxx'}},
+            {'logentry': {'message': 'Harvest job does not exist: xxx'}},
             {'logentry': {'message': 'Gather stage failed'}},
             {'logentry': {'message': '404 Not Found: Group not found'}},
             {'logentry': {'message': 'User  not authorised to create packages'}},


### PR DESCRIPTION
## What 

Ignore missing harvest jobs as probably due to mismatch between different environments during development work.