### PR TITLE
Remove maintenance banner

### DIFF
--- a/ckanext/datagovuk/templates/page.html
+++ b/ckanext/datagovuk/templates/page.html
@@ -1,9 +1,0 @@
-{% ckan_extends %}
-
-{% block flash %}
-{{ super() }}
-<div class="alert alert-warning">
-  <p>There will be a publishing freeze from 06:30am on 17th December to 11:59pm on 20th December.</p>
-  <p>The CKAN publishing tool will not be available. Users can access datasets on <a href="data.gov.uk">data.gov.uk</a> in the normal way during this time.</p>
-</div>
-{% endblock %}


### PR DESCRIPTION
## What

Remove the maintenance banner after the upgrade has complete.

## Reference 

https://trello.com/c/lkdK9QM2/71-do-the-postgres-upgrade-for-ckan