### PR TITLE
Add ci test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install harvester
       run: |
-        git clone https://github.com/ckan/ckanext-harvest
+        git clone --depth 1 https://github.com/ckan/ckanext-harvest
         cd ckanext-harvest
         pip install -r pip-requirements.txt
         pip install -r dev-requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       image: govuk/ckan-dev:2.9
     services:
       solr:
-        image: ckan/ckan-solr-dev:2.9
+        image: govuk/solr:6.6.2
       postgres:
         image: postgres:13.6
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       solr:
         image: govuk/solr:6.6.2
       postgres:
-        image: postgres:13.6
+        image: postgres:13.8-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: ckanext-datagovuk ci
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    container:
+      image: govuk/ckan-dev:2.9
+    services:
+      solr:
+        image: ckan/ckan-solr-dev:2.9
+      postgres:
+        image: postgres:13.6
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis:3
+    env:
+      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
+      CKAN_SOLR_URL: http://solr:8983/solr/ckan
+      CKAN_REDIS_URL: redis://redis:6379/1
+      CKAN_SITE_URL: http://test.ckan.net
+      PGPASSWORD: postgres
+      CRYPTOGRAPHY_DONT_BUILD_RUST: 1
+      TZ: UTC
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create Database
+      run: |
+        psql --host=postgres --username=postgres --command="CREATE USER ckan_default WITH PASSWORD 'pass' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
+        createdb --encoding=utf-8 --host=postgres --username=postgres --owner=ckan_default ckan_test
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install harvester
+      run: |
+        git clone https://github.com/ckan/ckanext-harvest
+        cd ckanext-harvest
+        pip install -r pip-requirements.txt
+        pip install -r dev-requirements.txt
+        pip install -e .
+    - name: Install requirements (ckanext-datagovuk)
+      run: |
+        pip install -r requirements.txt
+        pip install -e .
+    - name: Update config
+      run: |
+        # Replace default path to CKAN core config file with the one on the container
+        sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+        # set the i18n directory
+        sed -i -e "s|ckan.i18n_directory = .*$|ckan.i18n_directory = $(pwd)/ckanext/datagovuk/i18n|" /srv/app/production.ini
+    - name: Init Database
+      run: |
+        ckan db init
+    - name: Run tests
+      run: pytest --ckan-ini=test.ini tests --cov=ckanext.datagovuk --cov-report=term-missing --disable-pytest-warnings -v

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -185,6 +185,12 @@ class TestPackageController:
                     for k, v in actual.items()
                     if k in expected
                 }
+
+                # status is coming back as str type rather than json
+                # set it back to json for full comparison
+                if type(actual_common['status']) is str:
+                   actual_common['status'] = json.loads(actual_common['status'])
+
                 assert expected == actual_common
 
                 try:


### PR DESCRIPTION
## What 

Add github actions test to enable external users to upload changes to organogram test files.

## Reference 

https://trello.com/c/QAq4fYIX/918-add-ci-tests-to-github-actions-for-ckanext-datagovuk