### PR TITLE
Remove Jenkins Docker build tasks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,19 +25,9 @@ node ('!(ci-agent-4)') {
       sh("bash -c 'source venv/bin/activate ; ./bin/jenkins-tests.sh'")
     }
 
-    if (govuk.hasDockerfile()) {
-      govuk.dockerBuildTasks([:], "ckan")
-    }
-
     if (env.BRANCH_NAME == 'main') {
       stage('Push release tag') {
         govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER, 'main')
-      }
-
-      if (govuk.hasDockerfile()) {
-        stage("Tag Docker image") {
-          govuk.dockerTagBranch("ckan", env.BRANCH_NAME, env.BUILD_NUMBER)
-        }
       }
 
       stage('Deploy to Integration') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ node ('!(ci-agent-4)') {
       }
 
       stage('Deploy to Integration') {
-        govuk.deployIntegration('ckan', BRANCH_NAME, 'release_' + BUILD_NUMBER, 'deploy')
+        govuk.deployToIntegration('ckan', 'release_' + BUILD_NUMBER, 'deploy')
       }
     }
   } catch (e) {


### PR DESCRIPTION
Trello: https://trello.com/c/amnaU0V9/853-decommission-the-publishing-end-to-end-tests

The Docker functions are being removed from the govuk-jenkinslib as
their most significant need, publishing-e2e-tests, has been retired [1].

As far as I can tell no production systems make use of these images.
When this project is used by replatforming these will need to be pushed
to a different destination (ECR).

[1]: https://github.com/alphagov/govuk-jenkinslib/pull/120

This also resolves a deprecated function.