### PR TITLE
Upgrade CKAN to 2.9.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ node ('!(ci-agent-4)') {
 
     stage('Installing Packages for python 3 release') {
       sh("rm -rf ./venv")
-      sh("python3.6 -m venv ./venv")
+      sh("python3.7 -m venv ./venv")
       sh("bash -c 'venv/bin/python -m pip install --upgrade 'pip==21.2.2''")
       sh("./bin/install-dependencies.sh ./venv/bin/pip")
     }

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
-web: unicornherder --gunicorn-bin ./venv3/bin/gunicorn -p /var/run/ckan/unicornherder.pid wsgi:application --bind=localhost:${CKAN_PORT} --preload --pythonpath=/var/ckan --timeout ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/app29.out.log --error-logfile /var/log/ckan/app29.err.log
-pycsw_web: unicornherder --gunicorn-bin ./venv3/bin/gunicorn -p /var/run/ckan/pycsw_unicornherder.pid -- pycsw.wsgi -e PYCSW_CONFIG="/var/ckan/pycsw.cfg" --bind localhost:${PYCSW_PORT} --timeout ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/pycsw29.out.log --error-logfile /var/log/ckan/pycsw29.err.log
+web: unicornherder --gunicorn-bin ./venv37/bin/gunicorn -p /var/run/ckan/unicornherder.pid wsgi:application --bind=localhost:${CKAN_PORT} --preload --pythonpath=/var/ckan --timeout ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/app29.out.log --error-logfile /var/log/ckan/app29.err.log
+pycsw_web: unicornherder --gunicorn-bin ./venv37/bin/gunicorn -p /var/run/ckan/pycsw_unicornherder.pid -- pycsw.wsgi -e PYCSW_CONFIG="/var/ckan/pycsw.cfg" --bind localhost:${PYCSW_PORT} --timeout ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKER_PROCESSES} --log-file /var/log/ckan/pycsw29.out.log --error-logfile /var/log/ckan/pycsw29.err.log
 
-harvester_gather_consumer: ./venv3/bin/ckan -c ${CKAN_INI} harvester gather-consumer
-harvester_fetch_consumer: ./venv3/bin/ckan -c ${CKAN_INI} harvester fetch-consumer
+harvester_gather_consumer: ./venv37/bin/ckan -c ${CKAN_INI} harvester gather-consumer
+harvester_fetch_consumer: ./venv37/bin/ckan -c ${CKAN_INI} harvester fetch-consumer

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -11,9 +11,9 @@ ckan_dcat_sha='be3b809fa7431c8d81508c01853e81ce6a5dfd84'
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='433c7f2a4ba0b05871fe8bbc9b0518aa594f392d'
 
-# ckan 2.9.3 - with dgu fixes
-ckan_sha='bc7ed57aba16f755adb39a9b38d04d543a4f4be1'
-ckan_fork='alphagov'
+# ckan 2.9.7
+ckan_sha='0cb8a700d8254b429b37257a0b4e7a07d7d7c62e'
+ckan_fork='ckan'
 
 pycsw_tag='2.4.0'
 
@@ -30,13 +30,13 @@ $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_fork/c
 $pip install $pipopt -r https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirements.txt
 $pip install $pipopt -Ue "git+https://github.com/$ckan_fork/ckan.git@$ckan_sha#egg=ckan"
 
-$pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_harvest_fork/ckanext-harvest/$ckan_harvest_sha/pip-requirements.txt)
-$pip install $pipopt -U "git+https://github.com/$ckan_harvest_fork/ckanext-harvest.git@$ckan_harvest_sha#egg=ckanext-harvest"
-
 $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_dcat_fork/ckanext-dcat/$ckan_dcat_sha/requirements.txt)
 $pip install $pipopt -U "git+https://github.com/$ckan_dcat_fork/ckanext-dcat.git@$ckan_dcat_sha#egg=ckanext-dcat"
 
-$pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/geopython/pycsw.git/$pycsw_tag/requirements.txt)
+$pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_harvest_fork/ckanext-harvest/$ckan_harvest_sha/pip-requirements.txt)
+$pip install $pipopt -U "git+https://github.com/$ckan_harvest_fork/ckanext-harvest.git@$ckan_harvest_sha#egg=ckanext-harvest"
+
+$pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/geopython/pycsw/$pycsw_tag/requirements.txt)
 $pip install $pipopt -Ue "git+https://github.com/geopython/pycsw.git@$pycsw_tag#egg=pycsw"
 
 pycsw_src="$(/usr/bin/env python -m site | grep pycsw | sed "s:[ |,|']::g")"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ python-slugify==5.0.2
 Shapely>=1.2.13
 sentry-sdk==0.17.6
 six==1.15.0
-sqlalchemy==1.3.5
+SQLAlchemy==1.3.5
 xlrd==1.2.0


### PR DESCRIPTION
## What 

Upgrade of CKAN to 2.9.7 to resolve a security vulnerability

## Reference

https://trello.com/c/ouCltnih/1595-handle-ckan-user-security-vulnerability