### PR TITLE
Update dockerfiles to use latest spatial sha

### DIFF
--- a/docker/ckan/Dockerfile
+++ b/docker/ckan/Dockerfile
@@ -97,7 +97,7 @@ ENV ckan_harvest_sha='cb0a7034410f217b2274585cb61783582832c8d5'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-ENV ckan_spatial_sha='9f9a418c103b697e3ebef309802b7fb62cbf6344'
+ENV ckan_spatial_sha='c4ee93fdcd33eb3ba55a73957987cdad60754d68'
 ENV ckan_spatial_fork='alphagov'
 
 RUN echo "pip install DGU extensions..." && \

--- a/docker/pycsw/Dockerfile
+++ b/docker/pycsw/Dockerfile
@@ -93,7 +93,7 @@ ENTRYPOINT ["/pycsw-entrypoint.sh"]
 USER ckan
 EXPOSE 5000
 
-ENV ckan_spatial_sha='9f9a418c103b697e3ebef309802b7fb62cbf6344'
+ENV ckan_spatial_sha='c4ee93fdcd33eb3ba55a73957987cdad60754d68'
 ENV ckan_spatial_fork='alphagov'
 
 ENV ckan_harvest_fork='ckan'


### PR DESCRIPTION
## What

Update the spatial shas to improve pycsw load process so that it only processes the last 12 hours metadata_modified difference and not everything.

## Reference 

https://trello.com/c/GnDhUN6u/1140-improve-solr-reindexing-and-pycsw-loads-efficiency 