### PR TITLE
Add prometheus metrics endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+    - name: Install flask prometheus exporter
+      run: pip install prometheus-flask-exporter==0.20.3
     - name: Install harvester
       run: |
         git clone --depth 1 https://github.com/ckan/ckanext-harvest

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -25,6 +25,8 @@ $pip uninstall -y enum34
 
 # needed for harvester run-test to target harvest sources
 $pip install $pipopt -U factory-boy==2.12.0 mock==2.0.0 pytest==4.6.5
+# needs to be installed before CKAN for web assets to work
+$pip install $pipopt -U prometheus-flask-exporter==0.20.3
 
 $pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirement-setuptools.txt)
 $pip install $pipopt -r https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirements.txt

--- a/ckanext/datagovuk/views/metrics.py
+++ b/ckanext/datagovuk/views/metrics.py
@@ -1,0 +1,6 @@
+from flask import current_app, Response
+
+
+def metrics():
+    data, content_type = current_app._metrics.generate_metrics()
+    return Response(data, mimetype=content_type)

--- a/docker/ckan/Dockerfile
+++ b/docker/ckan/Dockerfile
@@ -71,9 +71,10 @@ ENV CKAN_INI $CKAN_CONFIG/production.ini
 ENV ckan_sha='0d714b258668ee78a0b19182c53b34689629df37'
 ENV ckan_fork='ckan'
 
-# Setup CKAN
+# Setup CKAN - need to install prometheus-flask-exporter as part of CKAN for ckanext-datagovuk assets to be made available
 
 RUN pip install -U pip && \
+    pip install $pipopt -U prometheus-flask-exporter==0.20.3 && \
     pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirement-setuptools.txt) && \
     pip install --upgrade --no-cache-dir -r https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirements.txt && \
     pip install $pipopt -Ue "git+https://github.com/$ckan_fork/ckan.git@$ckan_sha#egg=ckan" && \

--- a/docker/pycsw/Dockerfile
+++ b/docker/pycsw/Dockerfile
@@ -77,6 +77,7 @@ ENV ckan_fork='ckan'
 # Setup CKAN
 
 RUN pip install -U pip && \
+    pip install $pipopt -U prometheus-flask-exporter==0.20.3 && \
     pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirement-setuptools.txt) && \
     pip install --upgrade --no-cache-dir -r https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirements.txt && \
     pip install $pipopt -Ue "git+https://github.com/$ckan_fork/ckan.git@$ckan_sha#egg=ckan" && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,15 @@ beautifulsoup4==4.9.3
 blinker==1.4
 boto3==1.18.34
 gunicorn
+jinja2<3.1.0
 lxml>=2.3
 numpy==1.16.4
-psycopg2==2.8.6
 pandas==1.1.4
+#prometheus-flask-exporter==0.20.3 # installed in Dockerfile before CKAN
+psycopg2==2.8.6
 python-slugify==5.0.2
-Shapely>=1.2.13
 sentry-sdk==0.17.6
+Shapely>=1.2.13
 six==1.15.0
 sqlalchemy==1.3.5
 xlrd==1.2.0


### PR DESCRIPTION
## What

Note that prometheus-flask-exporter needs to be installed as part of CKAN otherwise datagovuk assets are not loaded by CKAN framework.

This is currently done in the CKAN and pycsw Dockerfiles

## Reference 

https://trello.com/c/KPzUKkgY/1146-add-metrics-to-ckan