### PR TITLE
Do not run metrics on /healthcheck endpoint

### DIFF
--- a/bin/setup_pycsw.sh
+++ b/bin/setup_pycsw.sh
@@ -9,5 +9,5 @@ done
 
 ckan ckan-pycsw setup -p $CKAN_CONFIG/pycsw.cfg
 
-echo "Update pycsw abstract index to allow for larger records"
-PGPASSWORD=ckan psql pycsw -h $CKAN_DB_HOST -U ckan -c "DROP INDEX ix_records_abstract;CREATE INDEX ix_records_abstract ON records((md5(abstract)));"
+echo "Drop ix_records_abstract if exists and create pycsw abstract index to allow for larger records"
+PGPASSWORD=ckan psql ckan -h $CKAN_DB_HOST -U ckan -c "DROP INDEX IF EXISTS ix_records_abstract;CREATE INDEX ix_records_abstract ON records((md5(abstract)));"

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -319,7 +319,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         sentry_sdk.init(before_send=self.before_send, integrations=[FlaskIntegration()])
 
         if not hasattr(app, '_metrics'):
-            metrics = PrometheusMetrics(app, excluded_paths=['/metrics'])
+            metrics = PrometheusMetrics(app, excluded_paths=['/metrics', '/healthcheck'])
             app._metrics = metrics
         return app
 

--- a/docker/ckan/Dockerfile
+++ b/docker/ckan/Dockerfile
@@ -122,3 +122,6 @@ RUN echo "pip install DGU extensions..." && \
     pip install $pipopt -U pyyaml==5.3.1
 
 RUN ckan config-tool $CKAN_INI "ckan.i18n_directory=$CKAN_VENV/src/ckanext-datagovuk/ckanext/datagovuk"
+
+# to run the CKAN wsgi set the WORKDIR to CKAN
+WORKDIR $CKAN_VENV/src/ckan/


### PR DESCRIPTION
## What 

Exclude /healthcheck from metrics and 

- fix bug in the pycsw script to run instead on CKAN database
- Set the WORKDIR to CKAN to make it easier to run a WSGI server

## Reference 

https://trello.com/c/GLNeQrpL/1148-use-wsgi-server-rather-than-flask-dev-server