### PR TITLE
Disable building images on schedule

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 3 * * *'
 
 jobs:
   build_and_push:


### PR DESCRIPTION
This functionality doesn't work since the build needs extra parameters that this trigger doesn't support, so it always fails.