### PR TITLE
Dockerfile name should have version prefix

### DIFF
--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -4,9 +4,9 @@ set -eux
 
 build () {
   if [ "${ARCH}" = "amd64" ]; then
-    docker build . -t "ghcr.io/alphagov/${APP}:${1}" -f "docker/${APP}/${1}.Dockerfile"
+    docker build . -t "ghcr.io/alphagov/${APP}:${1}" -f "docker/${APP}/${VERSION}.Dockerfile"
   else
-    docker buildx build --platform "linux/${ARCH}" . -t "ghcr.io/alphagov/${APP}:${1}" -f "docker/${APP}/${1}.Dockerfile"
+    docker buildx build --platform "linux/${ARCH}" . -t "ghcr.io/alphagov/${APP}:${1}" -f "docker/${APP}/${VERSION}.Dockerfile"
   fi
 }
 


### PR DESCRIPTION
Dockerfile is prefixed with version and not a git sha when building the image from a workflow trigger.