### PR TITLE
Update ckan 2.9.9

### DIFF
--- a/bin/setup_ckan.sh
+++ b/bin/setup_ckan.sh
@@ -27,4 +27,6 @@ if [ ! -z $SETUP_DGU_TEST_DATA ]; then
     ckan datagovuk create-dgu-test-data
 fi
 
+ckan config-tool "$CKAN_INI" "ckan.i18n_directory=$CKAN_VENV/src/ckanext-datagovuk/ckanext/datagovuk"
+
 exec "$@"

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -10,7 +10,7 @@ build () {
   fi
 }
 
-if [[ -n ${BUILD_BASE:-} ]]; then
+if [[ ${BUILD_BASE:-} = "true" ]]; then
   if [ "${APP}" = "ckan" ]; then
     build "${VERSION}-core" "${VERSION}-core"
     build "${VERSION}-base" "${VERSION}-base"

--- a/docker/ckan/2.9.9-core.Dockerfile
+++ b/docker/ckan/2.9.9-core.Dockerfile
@@ -61,7 +61,7 @@ ENV pipopt='--exists-action=b --force-reinstall'
 
 # ckan 2.9.9
 
-ENV ckan_sha='6eeac01b8989e8ab48b261937dd0f948324c2a86'
+ENV ckan_sha='13c6d752e86f0e3501f953a9fdde15d038bad87b'
 ENV ckan_fork='ckan'
 
 # Setup CKAN - need to install prometheus-flask-exporter as part of CKAN for ckanext-datagovuk assets to be made available

--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -8,7 +8,5 @@ RUN echo "pip install ckanext-datagovuk..." && \
     pip install $pipopt -U -r requirements.txt && \
     pip install $pipopt -U -e . 
 
-RUN ckan config-tool "$CKAN_INI" "ckan.i18n_directory=$CKAN_VENV/src/ckanext-datagovuk/ckanext/datagovuk"
-
 # to run the CKAN wsgi set the WORKDIR to CKAN
 WORKDIR "$CKAN_VENV/src/ckan/"

--- a/docker/solr/8.Dockerfile
+++ b/docker/solr/8.Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-solr:2.9-solr8
+FROM ckan/ckan-solr:2.9-solr8-spatial
 
 # Enviroment
 ENV SOLR_CORE ckan


### PR DESCRIPTION
## What 

Fix problems with manual build of images on branches used for testing integration deployments. 

Also update solr to use the spatial version and update CKAN to latest 2.9 version to fix search index rebuild problems.