### PR TITLE
Update 2.9.3 email fix

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -11,8 +11,8 @@ ckan_dcat_sha='be3b809fa7431c8d81508c01853e81ce6a5dfd84'
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='bac67ccb236b718d226ef5ac7844723222d3b5c5'
 
-# ckan 2.9.3 - alphagov/ckan/commits/fix-user-security
-ckan_sha='885f9e0b668e3496a8f2c0c0a9f1cb59bf810e16'
+# ckan 2.9.3 - alphagov/ckan/commits/fix-existing-email-validation
+ckan_sha='22613024e9a7303cb85438bd64ca67d168db5436'
 ckan_fork='alphagov'
 
 pycsw_tag='2.4.0'

--- a/docker/ckan/2.9.3.Dockerfile
+++ b/docker/ckan/2.9.3.Dockerfile
@@ -61,7 +61,7 @@ ENV CKAN_INI $CKAN_CONFIG/production.ini
 
 # alphagov 2.9.3
 
-ENV ckan_sha='885f9e0b668e3496a8f2c0c0a9f1cb59bf810e16'
+ENV ckan_sha='22613024e9a7303cb85438bd64ca67d168db5436'
 ENV ckan_fork='alphagov'
 
 # Setup CKAN - need to install prometheus-flask-exporter as part of CKAN for ckanext-datagovuk assets to be made available


### PR DESCRIPTION
## What

Update the CKAN sha to commit that has the email validation fix. 

This should be the least impact on the existing production stack as not sure if upgrading CKAN to 2.9.5 will introduce any other issues, whereas cherry picking the fix in our CKAN fork should fix the email validation issues experienced in 2ndline.

## Reference

https://trello.com/c/bQjFJgQh/1609-ckan-add-exception-handling-for-email-validation-error