### PR TITLE
Only run CKAN db init for new stacks

### DIFF
--- a/bin/setup_ckan.sh
+++ b/bin/setup_ckan.sh
@@ -7,7 +7,9 @@ while ! pg_isready -h $CKAN_DB_HOST -U ckan; do
   sleep 1;
 done
 
-ckan db init
+if [[ ${CKAN_DB_INIT:-} = "true" ]]; then
+    ckan db init
+fi
 
 if [ ! -z $CREATE_CKAN_ADMIN ]; then
     if (ckan user show ckan_admin | grep -q "User: None"); then


### PR DESCRIPTION
There's no need to run the db init normally as part of a start up script when connecting to an existing database so only do it for new stacks.