### PR TITLE
Update dockerfile spatial gemini 2.3

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -87,7 +87,7 @@ jobs:
         env:
           APP: ${{ matrix.app.name }}
           VERSION: '2.9.9'
-          TAG: '2.9.9-test-a'
+          TAG: '2.9.9-test-b'
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -18,6 +18,11 @@ on:
         required: true
         type: boolean
         default: false
+      buildCKANTestImage:
+        description: Build CKAN test image
+        required: true
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -75,6 +80,14 @@ jobs:
         env:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
+          ARCH: ${{ matrix.arch }}
+          BUILD_BASE: true
+        run: ./docker/build-image.sh
+      - name: Build and push CKAN test image only
+        if: ${{ (inputs.buildCKANTestImage && matrix.app.name == 'ckan') }}
+        env:
+          APP: ${{ matrix.app.name }}
+          VERSION: '2.9.9-test'
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -64,7 +64,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
           SKIP: ${{ matrix.app.skip }}
         run: ./docker/build-image.sh
-      - name: Build and push base images
+      - name: Build and push CKAN base image
         if: ${{ inputs.buildType == 'build_push_base' && matrix.app.name == 'ckan' }}
         env:
           APP: ${{ matrix.app.name }}
@@ -72,7 +72,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh
-      - name: Build and push pycsw 2.4.0 image only
+      - name: Build and push pycsw image
         if: ${{ inputs.buildType == 'build_push_pycsw' && matrix.app.name == 'pycsw' }}
         env:
           APP: ${{ matrix.app.name }}
@@ -81,7 +81,7 @@ jobs:
           BUILD_BASE: true
           SKIP: ${{ matrix.app.skip }}
         run: ./docker/build-image.sh
-      - name: Build and push CKAN test image only
+      - name: Build and push CKAN test image
         if: ${{ inputs.buildType == 'build_push_test_ckan' && matrix.app.name == 'ckan' }}
         env:
           APP: ${{ matrix.app.name }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -3,26 +3,16 @@ name: Build and push images
 on:
   workflow_dispatch:
     inputs:
-      noPushToRegistry:
-        description: Build only, skip pushing to registry
+      buildType:
+        description: Decide on what to build
         required: true
-        type: boolean
-        default: false
-      buildBaseImages:
-        description: Build base images
-        required: true
-        type: boolean
-        default: false
-      buildPycsw240Images:
-        description: Build pycsw 2.4.0 image
-        required: true
-        type: boolean
-        default: false
-      buildCKANTestImage:
-        description: Build CKAN test image
-        required: true
-        type: boolean
-        default: false
+        type: choice
+        options:
+          - build_push
+          - build_only
+          - build_push_base
+          - build_push_pycsw
+          - build_push_test_ckan
   push:
     branches:
       - main
@@ -59,7 +49,7 @@ jobs:
         with:
           ref: ${{ inputs.gitRef }}
       - name: Build images (without pushing to registry)
-        if: ${{ inputs.noPushToRegistry }}
+        if: ${{ inputs.buildType == 'build_only' }}
         env:
           DRY_RUN: "1"
           APP: ${{ matrix.app.name }}
@@ -67,7 +57,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: ./docker/build-image.sh
       - name: Build and push images
-        if: ${{ (!inputs.buildPycsw240Images && !inputs.noPushToRegistry && !inputs.buildBaseImages) || (!inputs.buildPycsw240Images && !inputs.noPushToRegistry && inputs.buildBaseImages && (matrix.app.name == 'ckan' || matrix.app.name == 'solr') ) }}
+        if: ${{ inputs.buildType == 'build_push' }}
         env:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
@@ -75,16 +65,25 @@ jobs:
           BUILD_BASE: ${{ inputs.buildBaseImages }}
           SKIP: ${{ matrix.app.skip }}
         run: ./docker/build-image.sh
+      - name: Build and push base images
+        if: ${{ inputs.buildType == 'build_push_base' && matrix.app.name == 'ckan' }}
+        env:
+          APP: ${{ matrix.app.name }}
+          VERSION: ${{ matrix.app.version }}
+          ARCH: ${{ matrix.arch }}
+          BUILD_BASE: ${{ inputs.buildBaseImages }}
+        run: ./docker/build-image.sh
       - name: Build and push pycsw 2.4.0 image only
-        if: ${{ (inputs.buildPycsw240Images && matrix.app.name == 'pycsw' && matrix.app.version == '2.4.0g') }}
+        if: ${{ inputs.buildType == 'build_push_pycsw' && matrix.app.name == 'pycsw' }}
         env:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
+          SKIP: ${{ matrix.app.skip }}
         run: ./docker/build-image.sh
       - name: Build and push CKAN test image only
-        if: ${{ (inputs.buildCKANTestImage && matrix.app.name == 'ckan') }}
+        if: ${{ inputs.buildType == 'build_push_test_ckan' && matrix.app.name == 'ckan' }}
         env:
           APP: ${{ matrix.app.name }}
           VERSION: '2.9.9-test'

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -62,7 +62,6 @@ jobs:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
           ARCH: ${{ matrix.arch }}
-          BUILD_BASE: ${{ inputs.buildBaseImages }}
           SKIP: ${{ matrix.app.skip }}
         run: ./docker/build-image.sh
       - name: Build and push base images
@@ -71,7 +70,7 @@ jobs:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
           ARCH: ${{ matrix.arch }}
-          BUILD_BASE: ${{ inputs.buildBaseImages }}
+          BUILD_BASE: true
         run: ./docker/build-image.sh
       - name: Build and push pycsw 2.4.0 image only
         if: ${{ inputs.buildType == 'build_push_pycsw' && matrix.app.name == 'pycsw' }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -87,7 +87,7 @@ jobs:
         env:
           APP: ${{ matrix.app.name }}
           VERSION: '2.9.9'
-          TAG: '2.9.9-test'
+          TAG: '2.9.9-test-a'
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -86,7 +86,7 @@ jobs:
         env:
           APP: ${{ matrix.app.name }}
           VERSION: '2.9.9'
-          TAG: '2.9.9-test-b'
+          TAG: '2.9.9-test-c'
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -86,7 +86,8 @@ jobs:
         if: ${{ inputs.buildType == 'build_push_test_ckan' && matrix.app.name == 'ckan' }}
         env:
           APP: ${{ matrix.app.name }}
-          VERSION: '2.9.9-test'
+          VERSION: '2.9.9'
+          TAG: '2.9.9-test'
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -86,7 +86,7 @@ jobs:
         env:
           APP: ${{ matrix.app.name }}
           VERSION: '2.9.9'
-          TAG: '2.9.9-test-c'
+          TAG: '2.9.9-test-d'
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -41,5 +41,12 @@ else
   else
     docker push "ghcr.io/alphagov/${APP}:${VERSION}-core"
     docker push "ghcr.io/alphagov/${APP}:${VERSION}-base"
+
+    # tags only used for test images
+    if [[ -n ${TAG:-} ]]; then
+      build "${TAG}" "${VERSION}"
+      docker push "ghcr.io/alphagov/${APP}:${TAG}"
+    fi
+
   fi
 fi

--- a/docker/ckan/2.9.9-base.Dockerfile
+++ b/docker/ckan/2.9.9-base.Dockerfile
@@ -1,6 +1,8 @@
 FROM ghcr.io/alphagov/ckan:2.9.9-core
 
 COPY production.ini $CKAN_CONFIG/production.ini
+# Set CKAN_INI
+ENV CKAN_INI $CKAN_CONFIG/production.ini
 
 RUN chown -R ckan:ckan $CKAN_HOME $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH
 

--- a/docker/ckan/2.9.9-base.Dockerfile
+++ b/docker/ckan/2.9.9-base.Dockerfile
@@ -1,17 +1,5 @@
 FROM ghcr.io/alphagov/ckan:2.9.9-core
 
-# copy source files and copy production.ini & setup_ckan.sh
-COPY . $CKAN_VENV/src/ckanext-datagovuk/
-RUN cp -v $CKAN_VENV/src/ckanext-datagovuk/production.ini $CKAN_CONFIG/production.ini && \
-    cp -v $CKAN_VENV/src/ckanext-datagovuk/bin/setup_ckan.sh /ckan-entrypoint.sh && \
-    chmod +x /ckan-entrypoint.sh && \
-    chown -R ckan:ckan $CKAN_HOME $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH
-
-# Set CKAN_INI
-ENV CKAN_INI $CKAN_CONFIG/production.ini
-
-WORKDIR $CKAN_VENV/src/ckanext-datagovuk/
-
 USER ckan
 EXPOSE 5000
 
@@ -21,7 +9,7 @@ ENV ckan_harvest_sha='9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-ENV ckan_spatial_sha='91953714aad5ae993c9f5a5690bb8d51df1a10b1'
+ENV ckan_spatial_sha='28a9dd77a2b39fb0eb7a66133507cea9223df9aa'
 ENV ckan_spatial_fork='alphagov'
 
 RUN echo "pip install DGU extensions..." && \

--- a/docker/ckan/2.9.9-base.Dockerfile
+++ b/docker/ckan/2.9.9-base.Dockerfile
@@ -21,7 +21,7 @@ ENV ckan_harvest_sha='9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-ENV ckan_spatial_sha='de1f67cb7535d9b73079be6da56bf1b5d919a641'
+ENV ckan_spatial_sha='b8448136776b533a23d95db2caf8153b4a2e46ea'
 ENV ckan_spatial_fork='alphagov'
 
 RUN echo "pip install DGU extensions..." && \

--- a/docker/ckan/2.9.9-base.Dockerfile
+++ b/docker/ckan/2.9.9-base.Dockerfile
@@ -13,7 +13,7 @@ ENV ckan_harvest_sha='9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-ENV ckan_spatial_sha='28a9dd77a2b39fb0eb7a66133507cea9223df9aa'
+ENV ckan_spatial_sha='b552ae20fa546f7c6a8d17249c1cb33b12883d32'
 ENV ckan_spatial_fork='alphagov'
 
 WORKDIR $CKAN_VENV

--- a/docker/ckan/2.9.9-base.Dockerfile
+++ b/docker/ckan/2.9.9-base.Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/alphagov/ckan:2.9.9-core
 
+RUN chown -R ckan:ckan $CKAN_HOME $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH
+
 USER ckan
 EXPOSE 5000
 
@@ -11,6 +13,8 @@ ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
 ENV ckan_spatial_sha='28a9dd77a2b39fb0eb7a66133507cea9223df9aa'
 ENV ckan_spatial_fork='alphagov'
+
+WORKDIR $CKAN_VENV
 
 RUN echo "pip install DGU extensions..." && \
 

--- a/docker/ckan/2.9.9-base.Dockerfile
+++ b/docker/ckan/2.9.9-base.Dockerfile
@@ -21,7 +21,7 @@ ENV ckan_harvest_sha='9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-ENV ckan_spatial_sha='b8448136776b533a23d95db2caf8153b4a2e46ea'
+ENV ckan_spatial_sha='91953714aad5ae993c9f5a5690bb8d51df1a10b1'
 ENV ckan_spatial_fork='alphagov'
 
 RUN echo "pip install DGU extensions..." && \

--- a/docker/ckan/2.9.9-base.Dockerfile
+++ b/docker/ckan/2.9.9-base.Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/alphagov/ckan:2.9.9-core
 
+COPY production.ini $CKAN_CONFIG/production.ini
+
 RUN chown -R ckan:ckan $CKAN_HOME $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH
 
 USER ckan

--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -11,9 +11,6 @@ RUN chown -R ckan:ckan $CKAN_VENV
 
 USER ckan
 
-# Set CKAN_INI
-ENV CKAN_INI $CKAN_CONFIG/production.ini
-
 ENTRYPOINT ["/ckan-entrypoint.sh"]
 
 WORKDIR $CKAN_VENV/src/ckanext-datagovuk/

--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -9,7 +9,7 @@ RUN echo "pip install ckanext-datagovuk..." && \
     # force reinstall of spatial
     curl -s "https://raw.githubusercontent.com/$ckan_spatial_fork/ckanext-spatial/$ckan_spatial_sha/requirements.txt" > spatial-requirements.txt && \
     pip install $pipopt -r spatial-requirements.txt && \
-    pip install $pipopt -U "git+https://github.com/$ckan_spatial_fork/ckanext-spatial.git@$ckan_spatial_sha#egg=ckanext-spatial"
+    pip install $pipopt -U "git+https://github.com/$ckan_spatial_fork/ckanext-spatial.git@$ckan_spatial_sha#egg=ckanext-spatial" && \
 
     # need to pin pyyaml to correctly pick up config settings
     pip install $pipopt -U pyyaml==5.4 && \

--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -1,18 +1,20 @@
 FROM ghcr.io/alphagov/ckan:2.9.9-base
 
+# copy source files and copy production.ini & setup_ckan.sh
+COPY . $CKAN_VENV/src/ckanext-datagovuk/
+RUN cp -v $CKAN_VENV/src/ckanext-datagovuk/production.ini $CKAN_CONFIG/production.ini && \
+    cp -v $CKAN_VENV/src/ckanext-datagovuk/bin/setup_ckan.sh /ckan-entrypoint.sh && \
+    chmod +x /ckan-entrypoint.sh && \
+    chown -R ckan:ckan $CKAN_HOME $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH
+
+# Set CKAN_INI
+ENV CKAN_INI $CKAN_CONFIG/production.ini
+
 ENTRYPOINT ["/ckan-entrypoint.sh"]
 
-ENV ckan_spatial_sha='91953714aad5ae993c9f5a5690bb8d51df1a10b1'
+WORKDIR $CKAN_VENV/src/ckanext-datagovuk/
 
 RUN echo "pip install ckanext-datagovuk..." && \
-
-    # force reinstall of spatial
-    curl -s "https://raw.githubusercontent.com/$ckan_spatial_fork/ckanext-spatial/$ckan_spatial_sha/requirements.txt" > spatial-requirements.txt && \
-    pip install $pipopt -r spatial-requirements.txt && \
-    pip install $pipopt -U "git+https://github.com/$ckan_spatial_fork/ckanext-spatial.git@$ckan_spatial_sha#egg=ckanext-spatial" && \
-
-    # need to pin pyyaml to correctly pick up config settings
-    pip install $pipopt -U pyyaml==5.4 && \
 
     # install ckanext-datagovuk
     pip install $pipopt -U -r requirements.txt && \

--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -1,11 +1,14 @@
 FROM ghcr.io/alphagov/ckan:2.9.9-base
 
+USER root
+
 # copy source files and copy production.ini & setup_ckan.sh
 COPY . $CKAN_VENV/src/ckanext-datagovuk/
 RUN cp -v $CKAN_VENV/src/ckanext-datagovuk/production.ini $CKAN_CONFIG/production.ini && \
     cp -v $CKAN_VENV/src/ckanext-datagovuk/bin/setup_ckan.sh /ckan-entrypoint.sh && \
-    chmod +x /ckan-entrypoint.sh && \
-    chown -R ckan:ckan $CKAN_HOME $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH
+    chmod +x /ckan-entrypoint.sh
+
+USER ckan
 
 # Set CKAN_INI
 ENV CKAN_INI $CKAN_CONFIG/production.ini

--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -7,6 +7,7 @@ COPY . $CKAN_VENV/src/ckanext-datagovuk/
 RUN cp -v $CKAN_VENV/src/ckanext-datagovuk/production.ini $CKAN_CONFIG/production.ini && \
     cp -v $CKAN_VENV/src/ckanext-datagovuk/bin/setup_ckan.sh /ckan-entrypoint.sh && \
     chmod +x /ckan-entrypoint.sh
+RUN chown -R ckan:ckan $CKAN_VENV
 
 USER ckan
 

--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -2,7 +2,17 @@ FROM ghcr.io/alphagov/ckan:2.9.9-base
 
 ENTRYPOINT ["/ckan-entrypoint.sh"]
 
+ENV ckan_spatial_sha='91953714aad5ae993c9f5a5690bb8d51df1a10b1'
+
 RUN echo "pip install ckanext-datagovuk..." && \
+
+    # force reinstall of spatial
+    curl -s "https://raw.githubusercontent.com/$ckan_spatial_fork/ckanext-spatial/$ckan_spatial_sha/requirements.txt" > spatial-requirements.txt && \
+    pip install $pipopt -r spatial-requirements.txt && \
+    pip install $pipopt -U "git+https://github.com/$ckan_spatial_fork/ckanext-spatial.git@$ckan_spatial_sha#egg=ckanext-spatial"
+
+    # need to pin pyyaml to correctly pick up config settings
+    pip install $pipopt -U pyyaml==5.4 && \
 
     # install ckanext-datagovuk
     pip install $pipopt -U -r requirements.txt && \

--- a/docker/docker-compose-2.9.3.yml
+++ b/docker/docker-compose-2.9.3.yml
@@ -35,7 +35,7 @@ services:
     image: localhost:53492/pycsw:2.6.1
     build:
       context: ../
-      dockerfile: docker/pycsw/2.9.3.Dockerfile
+      dockerfile: docker/pycsw/2.4.0g.Dockerfile
 
     links:
       - db-2.9.3:db
@@ -57,7 +57,7 @@ services:
       - .env-2.9.3
     build:
       context: ../
-      dockerfile: docker/postgis/Dockerfile
+      dockerfile: docker/postgis/13-3.1.Dockerfile
     volumes:
       - pg_data-2.9.3:/var/lib/postgresql/data
     networks:
@@ -65,11 +65,9 @@ services:
 
   solr-2.9.3:
     container_name: solr-2.9.3
-    # image: ckan/ckan-solr:2.9-solr8
     build:
       context: ../
-      dockerfile: docker/solr/Dockerfile
-      # dockerfile: Dockerfile.solr8
+      dockerfile: docker/solr/6.6.2.Dockerfile
     ports:
       - "8983:8983"
     volumes:
@@ -88,8 +86,8 @@ services:
   nginx-2.9.3:
     container_name: nginx-2.9.3
     build:
-      context: nginx/2.9.3/
-      dockerfile: Dockerfile
+      context: ../
+      dockerfile: docker/nginx/Dockerfile
     links:
       - ckan-2.9.3:ckan
     ports:


### PR DESCRIPTION
This PR contains a number of updates - 

- Updates the 2.9.9-base.Dockerfile to use a spatial sha that works with the gemini-csw harvest source.
- Fix the Dockerfiles as they would not have picked up changes in this repo in their previous form.
- Update the build-image.yaml to allow for clearer options for building and pushing images
- Make fixes to the docker-compose-2.9.3.yml in line with updated directory structure