### PR TITLE
Update create-pr.sh to handle duplicate branches

### DIFF
--- a/docker/create-pr.sh
+++ b/docker/create-pr.sh
@@ -20,16 +20,21 @@ cd charts/charts/ckan/images
 for ENV in $(echo $ENVS | tr "," " "); do
   (
     BRANCH="ci/${IMAGE_TAG}-${ENV}"
-    git checkout -b ${BRANCH}
 
-    cd "${ENV}"
-    for APP in ckan pycsw solr; do
-      yq -i '.tag = env(IMAGE_TAG)' "${APP}.yaml"
-      yq -i '.branch = env(SOURCE_BRANCH)' "${APP}.yaml"
-      git add "${APP}.yaml"
-    done
-    git commit -m "Update image tags for ${ENV} to ${IMAGE_TAG}"
-    git push --set-upstream origin "${BRANCH}"
-    gh pr create --title "Update image tags for ${ENV} (${IMAGE_TAG})" --base main --head "${BRANCH}" --fill
+    if git show-ref --quiet refs/heads/${BRANCH}; then
+      echo "Branch ${BRANCH} already exists on govuk-ckan-charts"
+    else
+      git checkout -b ${BRANCH}
+
+      cd "${ENV}"
+      for APP in ckan pycsw solr; do
+        yq -i '.tag = env(IMAGE_TAG)' "${APP}.yaml"
+        yq -i '.branch = env(SOURCE_BRANCH)' "${APP}.yaml"
+        git add "${APP}.yaml"
+      done
+      git commit -m "Update image tags for ${ENV} to ${IMAGE_TAG}"
+      git push --set-upstream origin "${BRANCH}"
+      gh pr create --title "Update image tags for ${ENV} (${IMAGE_TAG})" --base main --head "${BRANCH}" --fill
+    fi
   )
 done


### PR DESCRIPTION
This should stop the GHA failures due to trying to push commits to an existing branch.