### PR TITLE
Show the publishing freeze maintenance banner

### DIFF
--- a/ckanext/datagovuk/templates/page.html
+++ b/ckanext/datagovuk/templates/page.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block flash %}
+{{ super() }}
+<div class="alert alert-warning">
+  <p>There will be a publishing freeze from 06:30am on 20th September to 11:59pm on 21st September.</p>
+  <p>The CKAN publishing tool will not be available. Users can access datasets on <a href="data.gov.uk">data.gov.uk</a> in the normal way during this time.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## What

Show the maintenance banner to publishers in case they are not registered as admin users so didn't get the email.

## Reference 

https://trello.com/c/vGRauGZi/1223-setup-maintenance-ckan-banner