### PR TITLE
Update CKAN sha to use fix fo g.__timer

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -11,8 +11,8 @@ ckan_dcat_sha='be3b809fa7431c8d81508c01853e81ce6a5dfd84'
 ckan_spatial_fork='alphagov'
 ckan_spatial_sha='3004c0f191831a66cb6b5d1ec6f521e3ff35353c'
 
-# ckan 2.9.3 - alphagov/ckan/commits/fix-existing-email-validation
-ckan_sha='22613024e9a7303cb85438bd64ca67d168db5436'
+# ckan 2.9.3 - alphagov/ckan/commits/fix-g-timer
+ckan_sha='f977dae6cf1cc73ad64d446f62d703c1827529df'
 ckan_fork='alphagov'
 
 pycsw_tag='2.4.0'


### PR DESCRIPTION
Update to the CKAN sha to fix an issue with g.__timer which is causing timeouts on Staging.

Details are explained here - https://github.com/ckan/ckan/issues/4576
