### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    name: test
     strategy:
       matrix:
         version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,13 @@ on:
 jobs:
   test:
     name: test
-    strategy:
-      matrix:
-        version:
-          - ckan: ghcr.io/alphagov/ckan:2.9.9-base
-            solr: ghcr.io/alphagov/solr:8-2.9f
-    name: test
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.version.ckan }}
+      image: ghcr.io/alphagov/ckan:2.9.9-base
       options: --user root
     services:
       solr:
-        image: ${{ matrix.version.solr }}
+        image: ghcr.io/alphagov/solr:8-2.9f
       postgres:
         image: postgis/postgis:13-3.1-alpine
         env:


### PR DESCRIPTION
Matrix is no longer needed as only testing against 1 version of the technical stack