### PR TITLE
Group metrics by url_rule

### DIFF
--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -319,7 +319,7 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
         sentry_sdk.init(before_send=self.before_send, integrations=[FlaskIntegration()])
 
         if not hasattr(app, '_metrics'):
-            metrics = PrometheusMetrics(app, excluded_paths=['/metrics', '/healthcheck'])
+            metrics = PrometheusMetrics(app, excluded_paths=['/metrics', '/healthcheck'], group_by='url_rule')
             app._metrics = metrics
         return app
 

--- a/docker/create-pr.sh
+++ b/docker/create-pr.sh
@@ -32,10 +32,11 @@ for ENV in $(echo $ENVS | tr "," " "); do
         yq -i '.branch = env(SOURCE_BRANCH)' "${APP}.yaml"
         git add "${APP}.yaml"
       done
-      git commit -m "Update image tags for ${ENV} to ${IMAGE_TAG}"
+
       if [[ $(git status | grep "nothing to commit") ]]; then
         echo "Nothing to commit"
       else
+        git commit -m "Update image tags for ${ENV} to ${IMAGE_TAG}"
         git push --set-upstream origin "${BRANCH}"
         gh pr create --title "Update image tags for ${ENV} (${IMAGE_TAG})" --base main --head "${BRANCH}" --fill
       fi


### PR DESCRIPTION
By default the Flask prometheus exporter groups its metrics by path. This results in a huge number of labels (currently 366,675 series), which makes for expensive queries and is generally not good for a healthy Prometheus.

Try grouping by url_rule, which should cut things down into fewer buckets.

Alternatively, we could group by endpoint, but the metrics currently look like everything is just reported under one "http" endpoint, so that might be too coarse.