### PR TITLE
Remove extra square bracket as causes error

### DIFF
--- a/bin/setup_ckan.sh
+++ b/bin/setup_ckan.sh
@@ -7,7 +7,7 @@ while ! pg_isready -h $CKAN_DB_HOST -U ckan; do
   sleep 1;
 done
 
-if [[ ${CKAN_DB_INIT:-} = "true" ]]; then
+if [ ${CKAN_DB_INIT:-} = "true" ]; then
     ckan db init
 fi
 


### PR DESCRIPTION
This only really affects deployment of a new cluster for local development but its good to fix so that local dev clusters can easily be spun up.