### PR TITLE
Update edit user form for clearer sysadmin UI when managing users

### DIFF
--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -33,13 +33,37 @@
 
     {% block extra_fields %}
     {% endblock %}
-    
+ 
+    {% if is_sysadmin and g.user != data.name %}
+    {% block sysadmin_password %}
+      <fieldset>
+        <legend>{{ _('Change ' + data.name|capitalize + "'s" + ' password') }}</legend>
+        {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off', 'pattern': '.{8,}', 'title': 'Password must be a minimum of 8 characters'} ) }}
+        {{ form.input('password2', type='password', label=_('Confirm Password'), id='field-password-confirm', value=data.password2, error=errors.password2, classes=['control-medium'], attrs={'autocomplete': 'off', 'pattern': '.{8,}', 'title': 'Password must be a minimum of 8 characters'}) }}
+      </fieldset>
+
+    <fieldset>
+      <legend>{{ _('Sysadmin password') }}</legend>
+        {{ form.input('old_password',
+                      type='password',
+                      label=_('Sysadmin Password'),
+                      id='field-password-old',
+                      value=data.oldpassword,
+                      error=errors.oldpassword,
+                      classes=['control-medium'],
+                      attrs={'autocomplete': 'off', 'class': 'form-control'}
+                      ) }}
+
+      </fieldset>
+    {% endblock %}
+
+    {% else %}
     {% block change_password %}
       <fieldset>
         <legend>{{ _('Change password') }}</legend>
         {{ form.input('old_password',
                       type='password',
-                      label=_('Sysadmin Password') if c.is_sysadmin else _('Old Password'),
+                      label=_('Old Password'),
                       id='field-password',
                       value=data.oldpassword,
                       error=errors.oldpassword,
@@ -54,6 +78,7 @@
 
       {% snippet "user/snippets/password_guidelines.html" %}
     {% endblock %}
+    {% endif %}
 
     <div class="form-actions">
       {% block form_actions %}

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -16,13 +16,6 @@
 
         {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
 
-        {% if c.show_email_notifications %}
-          {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=c.userobj.activity_streams_email_notifications) %}
-          {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
-          {{ form.info(helper_text.format(site_title=g.site_title), classes=['info-help-tight']) }}
-          {% endcall %}
-        {% endif %}
-
         {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
         {% set is_url = data.image_url and data.image_url.startswith('http') %}
 

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -1,6 +1,6 @@
 {% import 'macros/form.html' as form %}
 
-<form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}">
+<form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
   {{ form.errors(error_summary) }}
 
   <fieldset>
@@ -20,6 +20,11 @@
       {% endcall %}
     {% endif %}
 
+    {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+    {% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
+  
   </fieldset>
 
   <fieldset>

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -34,7 +34,7 @@
     {% endif %}
     {% endblock %}
  
-    {% if is_sysadmin and current_user.name != data.name %}
+    {% if is_sysadmin and g.user.name != data.name %}
     {% block sysadmin_old_password %}
       <fieldset>
         <legend>{{ _('Change ' + data.name|capitalize + "'s" + ' password') }}</legend>

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -3,6 +3,7 @@
 {% block form %}
 
   <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     {{ form.errors(error_summary) }}
 
     {% block core_fields %}

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -3,7 +3,7 @@
 {% block core_fields %}
 
   <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
-    <input type="hidden" name="{{ g.csrf_field_name }}" value="{{ csrf_token() }}"/>
+    {{ form.csrf_protection() }}
     {% block form_errors %}{{ form.errors(error_summary) }}{% endblock %}
 
     {% block sysadmin_password %}

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -1,63 +1,75 @@
 {% import 'macros/form.html' as form %}
 
-<form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
-  {{ form.errors(error_summary) }}
+{% block form %}
 
-  <fieldset>
-    <legend>{{ _('Change details') }}</legend>
-    {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+  <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
+    {{ form.errors(error_summary) }}
 
-    {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
+    {% block core_fields %}
+      <fieldset>
+        <legend>{{ _('Change details') }}</legend>
+        {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
 
-    {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=true) }}
+        {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 
-    {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
+        {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=true) }}
 
-    {% if c.show_email_notifications %}
-      {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=c.userobj.activity_streams_email_notifications) %}
-      {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
-      {{ form.info(helper_text.format(site_title=g.site_title), classes=['info-help-tight']) }}
-      {% endcall %}
-    {% endif %}
+        {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
 
-    {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
-    {% set is_url = data.image_url and data.image_url.startswith('http') %}
+        {% if c.show_email_notifications %}
+          {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=c.userobj.activity_streams_email_notifications) %}
+          {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
+          {{ form.info(helper_text.format(site_title=g.site_title), classes=['info-help-tight']) }}
+          {% endcall %}
+        {% endif %}
 
-    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label=_('Profile picture'), url_label=_('Profile picture URL') ) }}
-  
-  </fieldset>
+        {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+        {% set is_url = data.image_url and data.image_url.startswith('http') %}
 
-  <fieldset>
-    <legend>{{ _('Change password') }}</legend>
-    {{ form.input('old_password',
-                  type='password',
-                  label=_('Sysadmin Password') if c.is_sysadmin else _('Old Password'),
-                  id='field-password',
-                  value=data.oldpassword,
-                  error=errors.oldpassword,
-                  classes=['control-medium'],
-                  attrs={'autocomplete': 'off'}
-                  ) }}
-
-    {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off', 'pattern': '.{8,}', 'title': 'Password must be a minimum of 8 characters'} ) }}
-
-    {{ form.input('password2', type='password', label=_('Confirm Password'), id='field-password-confirm', value=data.password2, error=errors.password2, classes=['control-medium'], attrs={'autocomplete': 'off', 'pattern': '.{8,}', 'title': 'Password must be a minimum of 8 characters'}) }}
-  </fieldset>
-
-  {% snippet "user/snippets/password_guidelines.html" %}
-
-  <div class="form-actions">
-    {% block delete_button %}
-      {% if h.check_access('user_delete', {'id': data.id})  %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='user', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
-      {% endif %}
+        {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label=_('Profile picture'), url_label=_('Profile picture URL') ) }}
+    
+      </fieldset>
     {% endblock %}
-    {% block generate_button %}
-      {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
-        <a class="btn btn-warning" href="{% url_for controller='user', action='generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
-      {% endif %}
+
+    {% block extra_fields %}
     {% endblock %}
-    {{ form.required_message() }}
-    <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
-  </div>
-</form>
+    
+    {% block change_password %}
+      <fieldset>
+        <legend>{{ _('Change password') }}</legend>
+        {{ form.input('old_password',
+                      type='password',
+                      label=_('Sysadmin Password') if c.is_sysadmin else _('Old Password'),
+                      id='field-password',
+                      value=data.oldpassword,
+                      error=errors.oldpassword,
+                      classes=['control-medium'],
+                      attrs={'autocomplete': 'off'}
+                      ) }}
+
+        {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off', 'pattern': '.{8,}', 'title': 'Password must be a minimum of 8 characters'} ) }}
+
+        {{ form.input('password2', type='password', label=_('Confirm Password'), id='field-password-confirm', value=data.password2, error=errors.password2, classes=['control-medium'], attrs={'autocomplete': 'off', 'pattern': '.{8,}', 'title': 'Password must be a minimum of 8 characters'}) }}
+      </fieldset>
+
+      {% snippet "user/snippets/password_guidelines.html" %}
+    {% endblock %}
+
+    <div class="form-actions">
+      {% block form_actions %}
+        {% block delete_button %}
+          {% if h.check_access('user_delete', {'id': data.id})  %}
+            <a class="btn btn-danger pull-left" href="{% url_for controller='user', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+          {% endif %}
+        {% endblock %}
+        {% block generate_button %}
+          {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
+            <a class="btn btn-warning" href="{% url_for controller='user', action='generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
+          {% endif %}
+        {% endblock %}
+        {{ form.required_message() }}
+        <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
+      {% endblock %}
+    </div>
+  </form>
+{% endblock %}

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -23,7 +23,7 @@
     {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
     {% set is_url = data.image_url and data.image_url.startswith('http') %}
 
-    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label=_('Profile picture'), url_label=_('Profile picture URL') ) }}
   
   </fieldset>
 

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -27,7 +27,7 @@
     {% block extra_fields %}
     {% endblock %}
  
-    {% if is_sysadmin and g.user != data.name %}
+    {% if is_sysadmin and current_user.name != data.name %}
     {% block sysadmin_password %}
       <fieldset>
         <legend>{{ _('Change ' + data.name|capitalize + "'s" + ' password') }}</legend>

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -3,7 +3,7 @@
 {% block core_fields %}
 
   <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <input type="hidden" name="{{ g.csrf_field_name }}" value="{{ csrf_token() }}"/>
     {% block form_errors %}{{ form.errors(error_summary) }}{% endblock %}
 
     {% block sysadmin_password %}

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -87,11 +87,6 @@
             <a class="btn btn-danger pull-left" href="{% url_for controller='user', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
           {% endif %}
         {% endblock %}
-        {% block generate_button %}
-          {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
-            <a class="btn btn-warning" href="{% url_for controller='user', action='generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
-          {% endif %}
-        {% endblock %}
         {{ form.required_message() }}
         <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
       {% endblock %}

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -3,7 +3,7 @@
 {% block core_fields %}
 
   <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
-    {{ form.csrf_protection() }}
+    {{ h.csrf_input() }}
     {% block form_errors %}{{ form.errors(error_summary) }}{% endblock %}
 
     {% block sysadmin_password %}

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -1,12 +1,12 @@
 {% import 'macros/form.html' as form %}
 
-{% block form %}
+{% block core_fields %}
 
   <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-    {{ form.errors(error_summary) }}
+    {% block form_errors %}{{ form.errors(error_summary) }}{% endblock %}
 
-    {% block core_fields %}
+    {% block sysadmin_password %}
       <fieldset>
         <legend>{{ _('Change details') }}</legend>
         {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
@@ -29,7 +29,7 @@
     {% endblock %}
  
     {% if is_sysadmin and current_user.name != data.name %}
-    {% block sysadmin_password %}
+    {% block sysadmin_old_password %}
       <fieldset>
         <legend>{{ _('Change ' + data.name|capitalize + "'s" + ' password') }}</legend>
         {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off', 'pattern': '.{8,}', 'title': 'Password must be a minimum of 8 characters'} ) }}

--- a/ckanext/datagovuk/templates/user/edit_user_form.html
+++ b/ckanext/datagovuk/templates/user/edit_user_form.html
@@ -26,6 +26,12 @@
     {% endblock %}
 
     {% block extra_fields %}
+    {% if g.userobj.sysadmin and data.state == 'deleted' %}
+      {% call form.checkbox('activate_user', label=_('Reactivate User'), id='activate_user', value=True, checked=false) %}
+      {% set helper_text = _('This account is deactivated, if you want to reactivate it, please click on checkbox.') %}
+      {{ form.info(helper_text, classes='info-help-tight') }}
+      {% endcall %}
+    {% endif %}
     {% endblock %}
  
     {% if is_sysadmin and current_user.name != data.name %}
@@ -76,13 +82,16 @@
 
     <div class="form-actions">
       {% block form_actions %}
+      {% set is_deleted = data.state == 'deleted' %}
+      {% if not is_deleted %}
         {% block delete_button %}
           {% if h.check_access('user_delete', {'id': data.id})  %}
             <a class="btn btn-danger pull-left" href="{% url_for controller='user', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
           {% endif %}
         {% endblock %}
+        {% endif %}
         {{ form.required_message() }}
-        <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
+        <button class="btn btn-primary" type="submit" name="save">{{ _('Reactivate Profile') if is_deleted else _('Update Profile') }}</button>
       {% endblock %}
     </div>
   </form>

--- a/ckanext/datagovuk/templates/user/new_user_form.html
+++ b/ckanext/datagovuk/templates/user/new_user_form.html
@@ -1,7 +1,7 @@
 {% import "macros/form.html" as form %}
 
 <form id="user-register-form" class="form-horizontal" action="" method="post" enctype="multipart/form-data">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+  <input type="hidden" name="{{ g.csrf_field_name }}" value="{{ csrf_token() }}"/>
   {{ form.errors(error_summary) }}
   {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"]) }}
   {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"]) }}

--- a/ckanext/datagovuk/templates/user/new_user_form.html
+++ b/ckanext/datagovuk/templates/user/new_user_form.html
@@ -1,6 +1,6 @@
 {% import "macros/form.html" as form %}
 
-<form id="user-register-form" class="form-horizontal" action="" method="post">
+<form id="user-register-form" class="form-horizontal" action="" method="post" enctype="multipart/form-data">
   {{ form.errors(error_summary) }}
   {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"]) }}
   {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"]) }}
@@ -9,6 +9,11 @@
   {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", placeholder="••••••••", value=data.password2, error=errors.password2, classes=["control-medium"], attrs={'pattern': '.{8,}', 'title': 'Password must be a minimum of 8 characters'}) }}
 
   {% snippet "user/snippets/password_guidelines.html" %}
+
+  {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+  {% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+  {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
 
   {% if g.recaptcha_publickey %}
     {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}

--- a/ckanext/datagovuk/templates/user/new_user_form.html
+++ b/ckanext/datagovuk/templates/user/new_user_form.html
@@ -1,6 +1,7 @@
 {% import "macros/form.html" as form %}
 
 <form id="user-register-form" class="form-horizontal" action="" method="post" enctype="multipart/form-data">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
   {{ form.errors(error_summary) }}
   {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"]) }}
   {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"]) }}

--- a/ckanext/datagovuk/templates/user/new_user_form.html
+++ b/ckanext/datagovuk/templates/user/new_user_form.html
@@ -1,7 +1,7 @@
 {% import "macros/form.html" as form %}
 
 <form id="user-register-form" class="form-horizontal" action="" method="post" enctype="multipart/form-data">
-  <input type="hidden" name="{{ g.csrf_field_name }}" value="{{ csrf_token() }}"/>
+  {{ form.csrf_protection() }}
   {{ form.errors(error_summary) }}
   {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"]) }}
   {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"]) }}

--- a/ckanext/datagovuk/templates/user/new_user_form.html
+++ b/ckanext/datagovuk/templates/user/new_user_form.html
@@ -1,7 +1,7 @@
 {% import "macros/form.html" as form %}
 
 <form id="user-register-form" class="form-horizontal" action="" method="post" enctype="multipart/form-data">
-  {{ form.csrf_protection() }}
+  {{ h.csrf_input() }}
   {{ form.errors(error_summary) }}
   {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"]) }}
   {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"]) }}

--- a/ckanext/datagovuk/templates/user/new_user_form.html
+++ b/ckanext/datagovuk/templates/user/new_user_form.html
@@ -13,7 +13,7 @@
   {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
   {% set is_url = data.image_url and data.image_url.startswith('http') %}
 
-  {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
+  {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label=_('Profile picture'), url_label=_('Profile picture URL')) }}
 
   {% if g.recaptcha_publickey %}
     {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}


### PR DESCRIPTION
Updates the edit_user_form template in line with the upstream branch as it had gotten out of sync. 

The shas next to the commits headings indicate which commit shas the changes originated from in the ckan/ckan repo. 

This makes the update of user profiles by sysadmins a bit clearer and also empowers sysadmins to reactivate users without having to update the user state in the database.

Tested on integration.