### PR TITLE
Pin lxml to < 5.1.1

### DIFF
--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -19,7 +19,10 @@ RUN echo "pip install ckanext-datagovuk..." && \
 
     # install ckanext-datagovuk
     pip install $pipopt -U -r requirements.txt && \
-    pip install $pipopt -U -e . 
+    pip install $pipopt -U -e . && \
+
+    # pin lxml as 5.1.1 removes required property _ElementStringResult
+    pip install lxml==5.1.0
 
 # to run the CKAN wsgi set the WORKDIR to CKAN
 WORKDIR "$CKAN_VENV/src/ckan/"

--- a/docker/ckan/2.9.9.Dockerfile
+++ b/docker/ckan/2.9.9.Dockerfile
@@ -22,7 +22,8 @@ RUN echo "pip install ckanext-datagovuk..." && \
     pip install $pipopt -U -e . && \
 
     # pin lxml as 5.1.1 removes required property _ElementStringResult
-    pip install lxml==5.1.0
+    # TODO: revisit for CKAN 2.10 upgrade as might not be required
+    pip install lxml<5.1.1
 
 # to run the CKAN wsgi set the WORKDIR to CKAN
 WORKDIR "$CKAN_VENV/src/ckan/"


### PR DESCRIPTION
5.1.1 removes a require attribute _ElementStringResult which is causing problems with some harvest sources using XML.
