### PR TITLE
Update spatial sha to latest version with passing tests and update jinja2 requirement

### DIFF
--- a/docker/ckan/2.10.4-base.Dockerfile
+++ b/docker/ckan/2.10.4-base.Dockerfile
@@ -14,7 +14,7 @@ ENV ckan_harvest_sha='9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-ENV ckan_spatial_sha='43a5a453756431ee4d80053cad238cfe3628e4fa'
+ENV ckan_spatial_sha='1b9baee338ad5621878a5920c7c52148aef81359'
 ENV ckan_spatial_fork='alphagov'
 
 RUN echo "pip install DGU extensions..." && \

--- a/docker/pycsw/2.6.1.Dockerfile
+++ b/docker/pycsw/2.6.1.Dockerfile
@@ -98,7 +98,7 @@ WORKDIR $CKAN_VENV/src
 USER ckan
 EXPOSE 5000
 
-ENV ckan_spatial_sha='43a5a453756431ee4d80053cad238cfe3628e4fa'
+ENV ckan_spatial_sha='1b9baee338ad5621878a5920c7c52148aef81359'
 ENV ckan_spatial_fork='alphagov'
 
 ENV ckan_harvest_fork='ckan'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ blinker==1.4
 boto3==1.34.27
 ckantoolkit>=0.0.7
 gunicorn
-jinja2<3.1.0
+jinja2==3.1.*
 lxml<5.1.1
 numpy==1.26.3
 pandas==2.2.1


### PR DESCRIPTION
Update the spatial sha for CKAN and pycsw to latest version with passing tests. 

Also update the requirements jinja2 version to fix security vulnerability.