### PR TITLE
Add the migration script for audit purposes, script will be manually run

### DIFF
--- a/migrations/008_remove_harvest_coupled_resource.sql
+++ b/migrations/008_remove_harvest_coupled_resource.sql
@@ -1,0 +1,10 @@
+-- drop the harvest_coupled_resource table as it is preventing deletion of datasets
+-- when clearing a harvest source.
+-- The harvest_coupled_resource table is not referenced anywhere in the ckanext-harvest or ckan repo
+-- so it will be removed in order to stop the blocking of clearing harvest sources.
+
+BEGIN TRANSACTION;
+
+DROP table harvest_coupled_resource;
+
+COMMIT;


### PR DESCRIPTION
The harvest_coupled_resource table is preventing the harvest source datasets from being cleared so drop the table as it does not appear to be referenced anywhere in the main CKAN code or any extensions.