### PR TITLE
Add PATCH env to build-image-on-tags.yaml

### DIFF
--- a/.github/workflows/build-image-on-tags.yaml
+++ b/.github/workflows/build-image-on-tags.yaml
@@ -25,6 +25,7 @@ jobs:
         env:
           APP: ckan
           VERSION: 2.10.4
+          PATCH: a
           ARCH: amd64
           GH_REF: ${{ github.ref_name }}
         run: ./docker/build-image.sh


### PR DESCRIPTION
Without the PATCH env arg the build image won't be correct when releasing to Staging and Production.