### PR TITLE
Only build images and create chart PRs for alphagov

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -63,6 +63,7 @@ jobs:
         env:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
+          REPO_OWNER: ${{ github.repository_owner }}
           ARCH: ${{ matrix.arch }}
         run: ./docker/build-image.sh
       - name: Build and push CKAN base and core image
@@ -71,6 +72,7 @@ jobs:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
           PATCH: ${{ matrix.app.patch }}
+          REPO_OWNER: ${{ github.repository_owner }}
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh
@@ -80,6 +82,7 @@ jobs:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
           PATCH: ${{ matrix.app.patch }}
+          REPO_OWNER: ${{ github.repository_owner }}
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true
         run: ./docker/build-image.sh
@@ -89,6 +92,7 @@ jobs:
           APP: ${{ matrix.app.name }}
           VERSION: ${{ matrix.app.version }}
           PATCH: ${{ matrix.app.patch }}
+          REPO_OWNER: ${{ github.repository_owner }}
           ARCH: ${{ matrix.arch }}
           GH_REF: ${{ matrix.app.version }}
           BUILD_BASE: false
@@ -98,6 +102,7 @@ jobs:
         env:
           APP: ${{ matrix.app.name }}
           VERSION: '2.9.9'
+          REPO_OWNER: ${{ github.repository_owner }}
           TAG: '2.9.9-test-d'
           ARCH: ${{ matrix.arch }}
           BUILD_BASE: true

--- a/.github/workflows/create-pr-on-tags.yaml
+++ b/.github/workflows/create-pr-on-tags.yaml
@@ -18,5 +18,6 @@ jobs:
       - run: bash ./docker/create-pr.sh
         env:
           GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
           IS_TAG: "true"
           ENVS: "staging,production"

--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -24,5 +24,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}
           GH_REF: ${{ github.ref_name }}
+          REPO_OWNER: ${{ github.repository_owner }}
           IS_TAG: "false"
           ENVS: "integration"

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -2,6 +2,11 @@
 
 set -eux
 
+if [[ ${REPO_OWNER} != "alphagov" ]]; then
+  echo "Not alphagov so no need to build images PRs"
+  exit 0
+fi
+
 build () {
   if [ "${ARCH}" = "amd64" ]; then
     docker build . -t "ghcr.io/alphagov/${APP}:${1}" -f "docker/${APP}/${2}.Dockerfile"

--- a/docker/create-pr.sh
+++ b/docker/create-pr.sh
@@ -2,6 +2,11 @@
 
 set -eux
 
+if [[ ${REPO_OWNER} != "alphagov" ]]; then
+  echo "Not alphagov so no need to create chart PRs"
+  exit 0
+fi
+
 if [[ ${IS_TAG:-} = "true" ]]; then
   export IMAGE_TAG="${GH_REF}"
   export SOURCE_BRANCH="main"


### PR DESCRIPTION
This stops the build image and create chart PRs actions for forked repos as they will automatically fail.