### PR TITLE
Remove PATCH from build-image-on-tags as not needed

### DIFF
--- a/.github/workflows/build-image-on-tags.yaml
+++ b/.github/workflows/build-image-on-tags.yaml
@@ -25,7 +25,6 @@ jobs:
         env:
           APP: ckan
           VERSION: 2.10.4
-          PATCH: a
           ARCH: amd64
           GH_REF: ${{ github.ref_name }}
         run: ./docker/build-image.sh


### PR DESCRIPTION
The patch is not needed as the CKAN image is built against the Dockerfile and the pushed image is tagged by the release version.