### PR TITLE
Add REPO_OWNER env to build-image-on-tags.yaml

### DIFF
--- a/.github/workflows/build-image-on-tags.yaml
+++ b/.github/workflows/build-image-on-tags.yaml
@@ -25,6 +25,7 @@ jobs:
         env:
           APP: ckan
           VERSION: 2.10.4
+          REPO_OWNER: ${{ github.repository_owner }}
           ARCH: amd64
           GH_REF: ${{ github.ref_name }}
         run: ./docker/build-image.sh


### PR DESCRIPTION
Need the REPO_OWNER env var to determine whether to build the image or not in build-image.sh