### PR TITLE
Upgrade python 3.11

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -30,7 +30,7 @@ jobs:
         app:
           - name: ckan
             version: 2.10.4
-            patch: c
+            patch: d
           - name: pycsw
             version: 2.6.1
             patch: j

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alphagov/ckan:2.10.4-a-base
+      image: ghcr.io/alphagov/ckan:2.10.4-d-base
       options: --user root
     services:
       solr:

--- a/docker/ckan/2.10.4-base.Dockerfile
+++ b/docker/ckan/2.10.4-base.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM ghcr.io/alphagov/ckan:2.10.4-b-core
+FROM --platform=$TARGETPLATFORM ghcr.io/alphagov/ckan:2.10.4-d-core
 
 COPY production.ini $CKAN_CONFIG/production.ini
 # Set CKAN_INI

--- a/docker/ckan/2.10.4-core.Dockerfile
+++ b/docker/ckan/2.10.4-core.Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get -q -y update \
     && apt-get -q -y install \
         python3-pip \
         python3-wheel \
-        python3.10-venv \ 
-        python3.10-dev \
+        python3.11-venv \ 
+        python3.11-dev \
         libpq-dev \
         libmagic-dev \
         libxml2-dev \
@@ -53,7 +53,7 @@ RUN useradd -r -u 900 -m -c "ckan account" -d $CKAN_HOME -s /bin/false ckan
 
 # Setup virtual environment for CKAN
 RUN mkdir -p $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH && \
-    python3.10 -m venv $CKAN_VENV && \
+    python3.11 -m venv $CKAN_VENV && \
     ln -s $CKAN_VENV/bin/ckan /usr/local/bin/ckan
 
 

--- a/docker/ckan/2.10.4.Dockerfile
+++ b/docker/ckan/2.10.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM ghcr.io/alphagov/ckan:2.10.4-c-base
+FROM --platform=$TARGETPLATFORM ghcr.io/alphagov/ckan:2.10.4-d-base
 
 USER root
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ lxml<5.1.1
 numpy==1.26.3
 pandas==2.2.1
 #prometheus-flask-exporter==0.20.3 # installed in Dockerfile before CKAN
-psycopg2==2.8.6
+psycopg2==2.9.9
 python-slugify==5.0.2
 pytest==6.2.5
 openpyxl==3.1.2


### PR DESCRIPTION
Upgrading to python 3.11 should fix iso date format validation issues for fractional seconds reported by a publisher.