### PR TITLE
Pull down git updates

### DIFF
--- a/docker/create-pr.sh
+++ b/docker/create-pr.sh
@@ -22,6 +22,8 @@ git clone https://${GH_TOKEN}@github.com/alphagov/govuk-dgu-charts.git charts
 
 cd charts/charts/ckan/images
 
+git pull
+
 for ENV in $(echo $ENVS | tr "," " "); do
   (
     BRANCH="ci/${IMAGE_TAG}-${ENV}"


### PR DESCRIPTION
The github action appears to error as the latest updates haven't been pulled down but the branch is still created on DGU charts for Integration. Staging and Production branches are unaffected.