### PR TITLE
Add SQL script for reseting updated_at value for OS roads

### DIFF
--- a/migrations/010_reset_os_roads_updated_at.sql
+++ b/migrations/010_reset_os_roads_updated_at.sql
@@ -1,0 +1,8 @@
+-- The harvest_object_id was not being updated properly for OS Open roads datasets
+-- so reset the updated_at to before the metadata_modified_date in the harvest source to update them
+
+BEGIN TRANSACTION;
+
+UPDATE datasets SET updated_at = '2024-08-01' WHERE uuid IN ('65bf62c8-eae0-4475-9c16-a2e81afcbdb0', 'd34f5fb0-b40e-4641-a989-9c1f6f11348c');
+
+COMMIT;


### PR DESCRIPTION
This will ensure that the latest harvest_object_id is set.

The script will have to be run manually as there is no automatic application of these database scripts.