### PR TITLE
Hard code the build-image.yaml location as the runner cannot find the file

### DIFF
--- a/.github/workflows/build-image-on-tags.yaml
+++ b/.github/workflows/build-image-on-tags.yaml
@@ -1,6 +1,7 @@
 name: Build and push images on tags
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -14,7 +15,7 @@ jobs:
         with:
           ref: ${{ inputs.gitRef }}
       - name: Build and Push Tagged Image
-        uses: ./.github/workflows/build-image.yaml
+        uses: /home/runner/work/ckanext-datagovuk/ckanext-datagovuk/.github/workflows/build-image.yaml
         with:
           buildType: build_push_ckan
           gitRef: ${{ github.ref_name }}


### PR DESCRIPTION
Hard code the location of build-image.yaml and also allow the building of tagged images to be triggered manually for debug purposes