### PR TITLE
Fix build image on tags

### DIFF
--- a/.github/workflows/build-image-on-tags.yaml
+++ b/.github/workflows/build-image-on-tags.yaml
@@ -15,5 +15,5 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-image.yaml
     with:
-      buildType: build_push_ckan
+      buildType: build_push_ckan_with_gittag
       gitRef: ${{ github.ref_name }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -100,10 +100,9 @@ jobs:
           buildType="${{ env.BUILD_TYPE }}"
 
           if [ "$buildType" = "build_push_ckan_with_gittag" ]; then
-              TAG=`echo $(git fetch -t -q && git tag | sort --version-sort | tail -n1)`
-              echo "GH_REF=$TAG" >> $GITHUB_ENV
+            echo "GH_TAG=${{ inputs.gitRef || github.ref }}" >> $GITHUB_ENV
           else
-              echo "GH_REF=${{ github.sha }}" >> $GITHUB_ENV
+            echo "GH_TAG=${{ github.sha }}" >> $GITHUB_ENV
           fi
 
           case $buildType in
@@ -129,7 +128,7 @@ jobs:
             ;;
 
             "build_push_ckan_with_gittag")
-              echo "BUILD_TAGS=$TAG" >> $GITHUB_ENV
+              echo "BUILD_TAGS=${{ inputs.gitRef || github.ref }}" >> $GITHUB_ENV
               echo "DOCKERFILE=${{ matrix.app.version }}" >> $GITHUB_ENV
             ;;
 
@@ -148,7 +147,7 @@ jobs:
           images: |
             ${{ env.REGISTRY_BASE }}/${{ matrix.app.name }}
           tags: |
-            type=raw,value=${{ env.GH_REF }}
+            type=raw,value=${{ env.GH_TAG }}
             type=raw,value=${{ env.BUILD_TAGS }}${{ env.APP_TAG_SUFFIX }}
             type=raw,value=${{ env.BUILD_TAGS }}-${{ matrix.app.patch }}${{ env.APP_TAG_SUFFIX }},enable=${{ matrix.app.patch != '' && env.ADD_PATCH_TAG == 'true' }}
             type=sha,prefix${{ env.BUILD_TAGS }}${{ env.APP_TAG_SUFFIX }}-,format=short
@@ -260,12 +259,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.gitRef || github.ref }}
-          show-progress: false
-
       - name: Setup Docker BuildX
         uses: docker/setup-buildx-action@v3
 
@@ -280,16 +273,11 @@ jobs:
         id: determine-image-tags
         run: |
           buildType="${{ env.BUILD_TYPE }}"
-
+          
           if [ "$buildType" = "build_push_ckan_with_gittag" ]; then
-              sudo apt-get install -y git
-
-              # mkdir -p /tmp/digests/app
-
-              TAG=`echo $(git fetch -t -q && git tag | sort --version-sort | tail -n1)`
-              echo "GH_REF=$TAG" >> $GITHUB_ENV
+            echo "GH_TAG=${{ inputs.gitRef || github.ref }}" >> $GITHUB_ENV
           else
-              echo "GH_REF=${{ github.sha }}" >> $GITHUB_ENV
+            echo "GH_TAG=${{ github.sha }}" >> $GITHUB_ENV
           fi
 
           case $buildType in
@@ -313,7 +301,7 @@ jobs:
             ;;
 
             "build_push_ckan_with_gittag")
-              echo "BUILD_TAGS=$TAG" >> $GITHUB_ENV
+              echo "BUILD_TAGS=${{ inputs.gitRef || github.ref }}" >> $GITHUB_ENV
               echo "DOCKERFILE=${{ matrix.app.version }}" >> $GITHUB_ENV
             ;;
 
@@ -339,7 +327,7 @@ jobs:
           images: |
             ${{ env.REGISTRY_BASE }}/${{ matrix.app.name }}
           tags: |
-            type=raw,value=${{ env.GH_REF }}
+            type=raw,value=${{ env.GH_TAG }}
             type=raw,value=${{ env.BUILD_TAGS }}${{ env.APP_TAG_SUFFIX }}
             type=raw,value=${{ env.BUILD_TAGS }}-${{ matrix.app.patch }}${{ env.APP_TAG_SUFFIX }},enable=${{ matrix.app.patch != '' && env.ADD_PATCH_TAG == 'true' }}
             type=sha,prefix${{ env.BUILD_TAGS }}${{ env.APP_TAG_SUFFIX }}-,format=short
@@ -359,7 +347,6 @@ jobs:
         working-directory: /tmp/digests/app
         run: |
           tag_args=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          ls /tmp/digests -la
           printf -v sources "${IMAGEREF_PREFIX}@sha256:%s " *
           # shellcheck disable=SC2086 # Intentional word-splitting on $tag_args and $sources.
           docker buildx imagetools create $tag_args $sources

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -20,6 +20,7 @@ on:
         options:
           - build_only
           - build_push_ckan
+          - build_push_ckan_with_gittag
           - build_push_base
           - build_push_pycsw
           - build_push_solr
@@ -98,6 +99,13 @@ jobs:
         run: |
           buildType="${{ env.BUILD_TYPE }}"
 
+          if [ "$buildType" = "build_push_ckan_with_gittag" ]; then
+              TAG=`echo $(git fetch -t -q && git tag | sort --version-sort | tail -n1)`
+              echo "GH_REF=$TAG" >> $GITHUB_ENV
+          else
+              echo "GH_REF=${{ github.sha }}" >> $GITHUB_ENV
+          fi
+
           case $buildType in
             "build_only" | "build_push_pycsw")
               echo "BUILD_TAGS=${{ matrix.app.version }}" >> $GITHUB_ENV
@@ -120,6 +128,11 @@ jobs:
               echo "APP_TAG_SUFFIX=-core" >> $GITHUB_ENV
             ;;
 
+            "build_push_ckan_with_gittag")
+              echo "BUILD_TAGS=$TAG" >> $GITHUB_ENV
+              echo "DOCKERFILE=${{ matrix.app.version }}" >> $GITHUB_ENV
+            ;;
+
             *)
               echo "BUILD_TAGS=${{ matrix.app.version }}-${{ matrix.app.patch }}" >> $GITHUB_ENV
               echo "DOCKERFILE=${{ matrix.app.version }}-${{ matrix.app.patch }}" >> $GITHUB_ENV
@@ -135,7 +148,7 @@ jobs:
           images: |
             ${{ env.REGISTRY_BASE }}/${{ matrix.app.name }}
           tags: |
-            type=raw,value=${{ github.sha }}
+            type=raw,value=${{ env.GH_REF }}
             type=raw,value=${{ env.BUILD_TAGS }}${{ env.APP_TAG_SUFFIX }}
             type=raw,value=${{ env.BUILD_TAGS }}-${{ matrix.app.patch }}${{ env.APP_TAG_SUFFIX }},enable=${{ matrix.app.patch != '' && env.ADD_PATCH_TAG == 'true' }}
             type=sha,prefix${{ env.BUILD_TAGS }}${{ env.APP_TAG_SUFFIX }}-,format=short
@@ -247,17 +260,14 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.gitRef || github.ref }}
+          show-progress: false
+
       - name: Setup Docker BuildX
         uses: docker/setup-buildx-action@v3
-
-      - name: Show GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
-      - name: Get Git Head
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-        id: local-head
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -265,11 +275,22 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+  
       - name: Determine Image Tags
         id: determine-image-tags
         run: |
           buildType="${{ env.BUILD_TYPE }}"
+
+          if [ "$buildType" = "build_push_ckan_with_gittag" ]; then
+              sudo apt-get install -y git
+
+              # mkdir -p /tmp/digests/app
+
+              TAG=`echo $(git fetch -t -q && git tag | sort --version-sort | tail -n1)`
+              echo "GH_REF=$TAG" >> $GITHUB_ENV
+          else
+              echo "GH_REF=${{ github.sha }}" >> $GITHUB_ENV
+          fi
 
           case $buildType in
             "build_only" | "build_push_pycsw")
@@ -289,6 +310,11 @@ jobs:
               echo "DOCKERFILE=${{ matrix.app.version }}" >> $GITHUB_ENV
               echo "BUILD_CKAN_BASE=true" >> $GITHUB_ENV
               echo "APP_TAG_SUFFIX=-core" >> $GITHUB_ENV
+            ;;
+
+            "build_push_ckan_with_gittag")
+              echo "BUILD_TAGS=$TAG" >> $GITHUB_ENV
+              echo "DOCKERFILE=${{ matrix.app.version }}" >> $GITHUB_ENV
             ;;
 
             *)
@@ -313,7 +339,7 @@ jobs:
           images: |
             ${{ env.REGISTRY_BASE }}/${{ matrix.app.name }}
           tags: |
-            type=raw,value=${{ github.sha }}
+            type=raw,value=${{ env.GH_REF }}
             type=raw,value=${{ env.BUILD_TAGS }}${{ env.APP_TAG_SUFFIX }}
             type=raw,value=${{ env.BUILD_TAGS }}-${{ matrix.app.patch }}${{ env.APP_TAG_SUFFIX }},enable=${{ matrix.app.patch != '' && env.ADD_PATCH_TAG == 'true' }}
             type=sha,prefix${{ env.BUILD_TAGS }}${{ env.APP_TAG_SUFFIX }}-,format=short
@@ -333,6 +359,7 @@ jobs:
         working-directory: /tmp/digests/app
         run: |
           tag_args=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          ls /tmp/digests -la
           printf -v sources "${IMAGEREF_PREFIX}@sha256:%s " *
           # shellcheck disable=SC2086 # Intentional word-splitting on $tag_args and $sources.
           docker buildx imagetools create $tag_args $sources

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -19,6 +19,8 @@ build_types:
     - *app_solr
   build_push_ckan:
     - *app_ckan
+  build_push_ckan_with_gittag:
+    - *app_ckan
   build_push_base:
     - *app_ckan
   build_push_pycsw:


### PR DESCRIPTION
The image was being tagged with sha rather than version number upon git tag, the gitRef is now being used if it is provided and passed with the build_push_ckan_with_gittag input.