### PR TITLE
Remove dataset duplicates

### DIFF
--- a/build-config.yaml
+++ b/build-config.yaml
@@ -2,11 +2,11 @@ apps:
   ckan: &app_ckan
     name: ckan
     version: "2.10.4"
-    patch: f
+    patch: g
   pycsw: &app_pycsw
     name: pycsw
     version: "2.6.1"
-    patch: l
+    patch: m
   solr: &app_solr
     name: solr
     version: "2.10"

--- a/docker/ckan/2.10.4-base.Dockerfile
+++ b/docker/ckan/2.10.4-base.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/alphagov/ckan:2.10.4-f-core
+ARG BASE_IMAGE=ghcr.io/alphagov/ckan:2.10.4-g-core
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
 
 COPY production.ini $CKAN_CONFIG/production.ini
@@ -15,7 +15,7 @@ ENV ckan_harvest_sha='9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-ENV ckan_spatial_sha='23f9e5d0d07fa411ffea56498167da6a2c9a7df6'
+ENV ckan_spatial_sha='1eded8ad2236b3d885e56f9c39ffab52294fd4d0'
 ENV ckan_spatial_fork='alphagov'
 
 RUN echo "pip install DGU extensions..." && \

--- a/docker/ckan/2.10.4.Dockerfile
+++ b/docker/ckan/2.10.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/ckan:2.10.4-f-base
+FROM ghcr.io/alphagov/ckan:2.10.4-g-base
 
 USER root
 

--- a/docker/pycsw/2.6.1.Dockerfile
+++ b/docker/pycsw/2.6.1.Dockerfile
@@ -98,7 +98,7 @@ WORKDIR $CKAN_VENV/src
 USER ckan
 EXPOSE 5000
 
-ENV ckan_spatial_sha='23f9e5d0d07fa411ffea56498167da6a2c9a7df6'
+ENV ckan_spatial_sha='1eded8ad2236b3d885e56f9c39ffab52294fd4d0'
 ENV ckan_spatial_fork='alphagov'
 
 ENV ckan_harvest_fork='ckan'


### PR DESCRIPTION
The script will find all datasets which have more than 100 active datasets from the same publisher with the same title. 

These duplicate datasets come from 2 publishers so limit the deletions to the datasets from these publishers and reindex the latest dataset as it might have failed reindexing before due to a bug in the spatial extension which has been fixed. 

The dataset deletion is handled within CKAN as it will set the dataset state and reindex it rather than removing the datasets in case we need to change the dataset state back to active.