### PR TITLE
Bump Solr to 2.10-c for ARM flavour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       options: --user root
     services:
       solr:
-        image: ghcr.io/alphagov/solr:2.10-b
+        image: ghcr.io/alphagov/solr:2.10-c
       postgres:
         image: postgis/postgis:13-3.1-alpine
         env:

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -10,7 +10,7 @@ apps:
   solr: &app_solr
     name: solr
     version: "2.10"
-    patch: b
+    patch: c
 
 build_types:
   build_only:

--- a/docker/solr/2.10.Dockerfile
+++ b/docker/solr/2.10.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM solr:8
+FROM solr:8
 
 EXPOSE 8983
 
@@ -27,7 +27,7 @@ RUN chmod 644 $JTS_JAR_FILE
 # Add the spatial field type definitions and fields
 
 ## RPT
-ENV SOLR_RPT_FIELD_DEFINITION '<fieldType name="location_rpt"   class="solr.SpatialRecursivePrefixTreeFieldType" \
+ENV SOLR_RPT_FIELD_DEFINITION='<fieldType name="location_rpt"   class="solr.SpatialRecursivePrefixTreeFieldType" \
     spatialContextFactory="JTS"     \
     autoIndex="true"                \
     validationRule="repairBuffer0"  \


### PR DESCRIPTION
## What?
This just bumps the patch version for Solr to "c" so we can have a tagged ARM version available for testing.