### PR TITLE
Improve instructions for organogram publishing

### DIFF
--- a/ckanext/datagovuk/templates/package/snippets/resource_form.html
+++ b/ckanext/datagovuk/templates/package/snippets/resource_form.html
@@ -3,11 +3,13 @@
 {% block basic_fields_url %}
   {% if h.activate_upload(pkg_name) %}
       <div style="margin-left: 100px;margin-bottom: 20px;">
-          Additional help can be found in this <a target="newwin" href='https://guidance.data.gov.uk/publish_and_manage_data/harvest_or_add_data/add_data/#publishing-organograms'>guide to publishing organograms</a>
+          Additional help can be found in this <a target="newwin" href='https://guidance.data.gov.uk/publish_and_manage_data/harvest_or_add_data/add_data/#publishing-organograms'>guide to publishing organograms</a>.
       {% if h.is_central_gov_organogram(pkg_name) %}
         <br>
-          Ensure that you use this XLS template <a target="newwin" href='https://ckan.publishing.service.gov.uk/publisher-files/Blank_Organogram_Template_latest.xls'>standard template</a> which includes validation rules.
-          If you see an error message after clicking Publish please read it carefully and make corrections in your spreadsheet, before clicking Publish again.
+          You must use the <a target="newwin" href='https://ckan.publishing.service.gov.uk/publisher-files/Blank_Organogram_Template_latest.xls'>standard organogram template</a>.
+          If you do not use this template, or if you change it (such as removing, adding or renaming columns), you'll see an error and your publishing will not work.
+        <br>
+          The template includes validation rules. If you see an error message after clicking Publish please read it carefully and make corrections in your spreadsheet, before clicking Publish again.
       {% endif %}
       </div>
     {% endif %}


### PR DESCRIPTION
This makes it clearer that the organogram template must be used to avoid errors. 