### PR TITLE
⬆️ Bump actions/cache to 4.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           createdb --encoding=utf-8 --host=postgres --username=postgres --owner=ckan_default ckan_test
           psql --host=postgres --username=postgres -d ckan_test -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;"
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4.2.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
Actions cache v2 has started to brownout. We should look to move to the latest version.
