### PR TITLE
Catch value error organograms

### DIFF
--- a/build-config.yaml
+++ b/build-config.yaml
@@ -2,7 +2,7 @@ apps:
   ckan: &app_ckan
     name: ckan
     version: "2.10.4"
-    patch: j
+    patch: k
   pycsw: &app_pycsw
     name: pycsw
     version: "2.6.1"

--- a/ckanext/datagovuk/lib/organogram_xls_splitter.py
+++ b/ckanext/datagovuk/lib/organogram_xls_splitter.py
@@ -254,7 +254,7 @@ def load_references(xls_stream, errors, validation_errors):
                             '(reference) professions',
                             '(reference) units',
                         ])
-    except XLRDError as e:
+    except (ValueError, XLRDError) as e:
         if str(e) == "No sheet named <'(reference) units'>":
             validation_errors.append(str(e))
             return {}


### PR DESCRIPTION
Some publishers were having problems with the organograms but not able to see the all the validation errors. 
This should catch all ValueErrors to report back to the publisher so that they can amend their organogram file.

This has been tested on integration and works as expected.