### PR TITLE
Serve metrics alt port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .github
 .pytest_cache
 venv
+docker
+docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alphagov/ckan:2.10.4-e-base
+      image: ghcr.io/alphagov/ckan:2.10.7--base
       options: --user root
     services:
       solr:
@@ -80,7 +80,7 @@ jobs:
           # set the i18n directory
           sed -i -e "s|ckan.i18n_directory = .*$|ckan.i18n_directory = $CKAN_VENV/src/ckanext-datagovuk/ckanext/datagovuk/i18n|" "${CKAN_CONFIG}"/production.ini
       - name: Init Database
-        run: |
-          ckan db init
+        run: ckan db init
       - name: Run tests
-        run: pytest --ckan-ini=test.ini ckanext/datagovuk/tests --cov=ckanext.datagovuk --cov-report=term-missing --disable-pytest-warnings -v
+        run: |
+          PROMETHEUS_MULTIPROC_DIR="$RUNNER_TEMP" pytest --ckan-ini=test.ini ckanext/datagovuk/tests --cov=ckanext.datagovuk --cov-report=term-missing --disable-pytest-warnings -v

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import sys
 
 from ckan.plugins.toolkit import config
 import ckan.plugins as plugins

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -20,7 +20,7 @@ from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject
 
 from flask import Blueprint
 
-from prometheus_flask_exporter import PrometheusMetrics
+from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
 
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -313,8 +313,9 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, Defau
     def make_middleware(self, app, config):
         sentry_sdk.init(before_send=self.before_send, integrations=[FlaskIntegration()])
 
-        if not hasattr(app, '_metrics'):
-            metrics = PrometheusMetrics(app, excluded_paths=['/metrics', '/healthcheck'], group_by='url_rule')
+        # only add metrics once and not for the ckan db init command
+        if not hasattr(app, '_metrics') and not 'ckan db init' in ' '.join(sys.argv):
+            metrics = GunicornPrometheusMetrics(app, excluded_paths=['/metrics', '/healthcheck'], group_by='url_rule')
             app._metrics = metrics
         return app
 

--- a/docker/ckan/2.10.7.Dockerfile
+++ b/docker/ckan/2.10.7.Dockerfile
@@ -3,12 +3,16 @@ FROM ghcr.io/alphagov/ckan:2.10.7--base
 USER root
 
 COPY . $CKAN_VENV/src/ckanext-datagovuk/
-RUN cp -v $CKAN_VENV/src/ckanext-datagovuk/production.ini $CKAN_CONFIG/production.ini && \
-    cp -v $CKAN_VENV/src/ckanext-datagovuk/bin/setup_ckan.sh /ckan-entrypoint.sh && \
+COPY production.ini $CKAN_CONFIG/production.ini
+COPY gunicorn_config.py $CKAN_CONFIG/gunicorn_config.py
+RUN cp -v $CKAN_VENV/src/ckanext-datagovuk/bin/setup_ckan.sh /ckan-entrypoint.sh && \
     chmod +x /ckan-entrypoint.sh
 RUN chown -R ckan:ckan $CKAN_VENV
 
 USER ckan
+
+ENV PROMETHEUS_MULTIPROC_DIR='/tmp'
+ENV PROMETHEUS_METRICS_PORT=8080
 
 ENTRYPOINT ["/ckan-entrypoint.sh"]
 
@@ -18,7 +22,7 @@ RUN echo "pip install ckanext-datagovuk..." && \
 
     # install ckanext-datagovuk
     pip install $pipopt -U -r requirements.txt && \
-    pip install $pipopt -U -e . 
+    pip install $pipopt -U -e .
 
 # to run the CKAN wsgi set the WORKDIR to CKAN
 WORKDIR "$CKAN_VENV/src/ckan/"

--- a/docker/docker-compose-2.10.yml
+++ b/docker/docker-compose-2.10.yml
@@ -3,10 +3,10 @@ version: "3"
 services:
   ckan-2.10:
     container_name: ckan-2.10
-    image: ghcr.io/alphagov/ckan:2.10
-    # build:
-    #   context: ../
-    #   dockerfile: docker/ckan/2.10.Dockerfile
+    # image: ghcr.io/alphagov/ckan:2.10
+    build:
+      context: ckan/
+      dockerfile: 2.10.7.Dockerfile
     env_file:
       - .env-2.10
     links:
@@ -19,13 +19,14 @@ services:
     volumes:
       - ckan_storage-2.10:/var/lib/ckan
       - ./logs/2.10:/var/log/ckan
+      - ../ckanext/datagovuk/:/usr/lib/ckan/venv/src/ckanext-datagovuk/ckanext/datagovuk/
     depends_on: 
       - db-2.10
       - solr-2.10
       - redis-2.10
       - static-mock-harvest-source-2.10
-    # command: bash -c "tail -f /dev/null"
-    command: bash -c "ckan run --host 0.0.0.0"
+    command: bash -c "tail -f /dev/null"
+    # command: bash -c "ckan run --host 0.0.0.0"
     networks:
       - ckan-2.10
 
@@ -34,8 +35,8 @@ services:
     image: ghcr.io/alphagov/pycsw:2.6.1
     # image: localhost:61511/pycsw:2.6.1
     # build:
-    #   context: ../
-    #   dockerfile: docker/pycsw/2.6.1.Dockerfile
+    #   context: pycsw/
+    #   dockerfile: 2.6.1.Dockerfile
     env_file:
       - .env-2.10
     links:
@@ -57,8 +58,8 @@ services:
     env_file:
       - .env-2.10
     build:
-      context: ../
-      dockerfile: docker/postgis/13-3.1.Dockerfile
+      context: postgis/
+      dockerfile: 13-3.1.Dockerfile
     volumes:
       - pg_data-2.10:/var/lib/postgresql/data
     networks:
@@ -101,11 +102,10 @@ services:
 
   static-mock-harvest-source-2.10:
     container_name: static-mock-harvest-source-2.10
-    image: ghcr.io/alphagov/static-mock-harvest-source:2.10
+    # image: ghcr.io/alphagov/static-mock-harvest-source:2.10
     # image: localhost:61511/static-mock-harvest-source:2.10
-    # build:
-    #   context: ../
-    #   dockerfile: docker/src/2.10/ckan-mock-harvest-sources/static/Dockerfile
+    build:
+      context: src/2.10/ckan-mock-harvest-sources/static/
     ports:
       - "11091:11088"
     volumes:

--- a/docker/docker-compose-2.10.yml
+++ b/docker/docker-compose-2.10.yml
@@ -32,11 +32,11 @@ services:
 
   pycsw-2.10:
     container_name: pycsw-2.10
-    image: ghcr.io/alphagov/pycsw:2.6.1
+    # image: ghcr.io/alphagov/pycsw:2.6.1
     # image: localhost:61511/pycsw:2.6.1
-    # build:
-    #   context: pycsw/
-    #   dockerfile: 2.6.1.Dockerfile
+    build:
+      context: ../
+      dockerfile: ./docker/pycsw/2.6.1.Dockerfile
     env_file:
       - .env-2.10
     links:
@@ -57,9 +57,10 @@ services:
     container_name: db-2.10
     env_file:
       - .env-2.10
-    build:
-      context: postgis/
-      dockerfile: 13-3.1.Dockerfile
+    image: docker-db-2.10
+    # build:
+    #   context: postgis/
+    #   dockerfile: 13-3.1.Dockerfile
     volumes:
       - pg_data-2.10:/var/lib/postgresql/data
     networks:
@@ -88,9 +89,10 @@ services:
 
   nginx-2.10:
     container_name: nginx-2.10
-    build:
-      context: ../
-      dockerfile: docker/nginx/Dockerfile
+    image: docker-nginx-2.10 
+    # build:
+    #   context: ../
+    #   dockerfile: docker/nginx/Dockerfile
     links:
       - ckan-2.10:ckan
     ports:
@@ -104,8 +106,9 @@ services:
     container_name: static-mock-harvest-source-2.10
     # image: ghcr.io/alphagov/static-mock-harvest-source:2.10
     # image: localhost:61511/static-mock-harvest-source:2.10
-    build:
-      context: src/2.10/ckan-mock-harvest-sources/static/
+    image: docker-static-mock-harvest-source-2.10 
+    # build:
+    #   context: src/2.10/ckan-mock-harvest-sources/static/
     ports:
       - "11091:11088"
     volumes:

--- a/docker/docker-compose-2.10.yml
+++ b/docker/docker-compose-2.10.yml
@@ -5,8 +5,8 @@ services:
     container_name: ckan-2.10
     # image: ghcr.io/alphagov/ckan:2.10
     build:
-      context: ckan/
-      dockerfile: 2.10.7.Dockerfile
+      context: ../
+      dockerfile: docker/ckan/2.10.7.Dockerfile
     env_file:
       - .env-2.10
     links:

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,0 +1,10 @@
+import os
+from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
+
+
+def when_ready(server):
+    GunicornPrometheusMetrics.start_http_server_when_ready(int(os.getenv('PROMETHEUS_METRICS_PORT', 8080)))
+
+
+def child_exit(server, worker):
+    GunicornPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)


### PR DESCRIPTION
Start serving prometheus metrics on a separate port, default of 8080 or set by  `PROMETHEUS_METRICS_PORT` env var.

https://cddodatamarketplace.atlassian.net/browse/DGUK-39?atlOrigin=eyJpIjoiNzhmMjJhYmQwM2U0NDQzYjg1M2FkODJhODYyZjMzNjUiLCJwIjoiaiJ9