### PR TITLE
Add decorator to set site_url for test_plugin

### DIFF
--- a/ckanext/datagovuk/tests/test_plugin.py
+++ b/ckanext/datagovuk/tests/test_plugin.py
@@ -3,7 +3,9 @@ import unittest
 
 from ckan.lib.navl.dictization_functions import augment_data
 from ckan.lib.navl.validators import ignore
+from ckan.tests.helpers import change_config
 
+from ckanext.datagovuk.ckan_patches import helpers
 from ckanext.datagovuk.plugin import DatagovukPlugin
 from ckanext.datagovuk.action import create, get
 
@@ -58,6 +60,7 @@ class TestPlugin:
         assert ('invalid', 0, 'key') in data[('__junk',)]
         assert ('invalid', 0, 'value') in data[('__junk',)]
 
+    @change_config('ckan.site_url', 'http://test.ckan.net')
     def test_plugin_before_send(self):
         mock_event  = {
             'logentry': {
@@ -68,6 +71,7 @@ class TestPlugin:
 
         assert response == mock_event
 
+    @change_config('ckan.site_url', 'http://test.ckan.net')
     def test_plugin_before_send_ignores_data_errors(self):
         mock_events = [
             {'logentry': {'message': 'Found more than one dataset with the same guid xxx'}},


### PR DESCRIPTION
The site_url config was being overridden by the environment variable setting which then made the test fail, so ensure that the site_url is always set to http://test.ckan.net

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/362?selectedIssue=DGUK-50
