### PR TITLE
Fix smtp server connection

### DIFF
--- a/build-config.yaml
+++ b/build-config.yaml
@@ -2,7 +2,7 @@ apps:
   ckan: &app_ckan
     name: ckan
     version: "2.10.7"
-    patch: ""
+    patch: "a"
   pycsw: &app_pycsw
     name: pycsw
     version: "2.6.1"

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -33,7 +33,5 @@ build_types:
     - *app_ckan
 
 runs_on:
-  - runner_type: ubuntu-latest
-    arch: amd64
   - runner_type: ubuntu-24.04-arm
     arch: arm64

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -2,7 +2,7 @@ apps:
   ckan: &app_ckan
     name: ckan
     version: "2.10.7"
-    patch: "a"
+    patch: a
   pycsw: &app_pycsw
     name: pycsw
     version: "2.6.1"

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Default git fork
-CKAN_FORK=ckan
-CKAN_SHA=9f2094b26721b28918d45d58fea16176df7a1ce1
+CKAN_FORK=alphagov
+CKAN_SHA=dc5a8a6e4ab290f619fc52c5a3880376d7b3883c
+CKAN_REPO=ckan-fix
 DCAT_FORK=ckan
 DCAT_SHA=618928be5a211babafc45103a72b6aab4642e964
 
@@ -11,13 +12,13 @@ SPATIAL_SHA=c4938431346b50209d7bcf89a1a0154698b9f9f2
 HARVEST_FORK=ckan
 HARVEST_SHA=9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4
 SRC_DIR=2.10
-FIND_SHA=v3.2.6
+FIND_SHA=v3.8.0
 
 echo -e "Please ensure that the ${SRC_DIR} docker/src directory is empty before running this command. This command will not populate the directories required for this project to run effectively unless said directories are already empty or don't exist.\n"
 
 mkdir -p docker/src/$SRC_DIR
 pushd docker/src/$SRC_DIR
-(git clone https://github.com/$CKAN_FORK/ckan && cd ckan && git checkout $CKAN_SHA)
+(git clone https://github.com/$CKAN_FORK/$CKAN_REPO && cd $CKAN_REPO && git checkout $CKAN_SHA)
 
 (git clone https://github.com/$HARVEST_FORK/ckanext-harvest && cd ckanext-harvest && git checkout $HARVEST_SHA)
 (git clone https://github.com/$SPATIAL_FORK/ckanext-spatial && cd ckanext-spatial && git checkout $SPATIAL_SHA)

--- a/docker/ckan/2.10.7-base.Dockerfile
+++ b/docker/ckan/2.10.7-base.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/ckan:2.10.7--core
+FROM ghcr.io/alphagov/ckan:2.10.7-a-core
 
 COPY production.ini $CKAN_CONFIG/production.ini
 # Set CKAN_INI

--- a/docker/ckan/2.10.7-core.Dockerfile
+++ b/docker/ckan/2.10.7-core.Dockerfile
@@ -63,17 +63,18 @@ ENV PATH=${CKAN_VENV}/bin:${PATH}
 # Set pip args
 ENV pipopt='--exists-action=b --force-reinstall'
 
-# ckan 2.10.7
+# ckan 2.10.7 - alphagov branch to fix smtp connections on eu-west-2, see ckan-fix fork for details
 
-ENV ckan_sha='9f2094b26721b28918d45d58fea16176df7a1ce1'
-ENV ckan_fork='ckan'
+ENV ckan_sha='dc5a8a6e4ab290f619fc52c5a3880376d7b3883c'
+ENV ckan_fork='alphagov'
+ENV ckan_repo='ckan-fix'
 
 # Setup CKAN - need to install prometheus-flask-exporter as part of CKAN for ckanext-datagovuk assets to be made available
 
 RUN pip install -U pip && \
     pip install $pipopt -U cython pycryptodome==3.20 && \
     pip install $pipopt -U prometheus-flask-exporter==0.20.3 && \
-    pip install $pipopt -U $(curl -s https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirement-setuptools.txt) && \
+    pip install $pipopt -U $(curl -s "https://raw.githubusercontent.com/$ckan_fork/$ckan_repo/$ckan_sha/requirement-setuptools.txt") && \
     curl "https://raw.githubusercontent.com/$ckan_fork/ckan/$ckan_sha/requirements.txt" > requirements.txt && \
     pip install --upgrade --no-cache-dir -r requirements.txt && \
     pip install $pipopt -Ue "git+https://github.com/$ckan_fork/ckan.git@$ckan_sha#egg=ckan" && \

--- a/docker/ckan/2.10.7.Dockerfile
+++ b/docker/ckan/2.10.7.Dockerfile
@@ -21,7 +21,10 @@ WORKDIR $CKAN_VENV/src/ckanext-datagovuk/
 RUN echo "pip install ckanext-datagovuk..." && \
 
     # install ckanext-datagovuk
+    # setuptools pkg_resources has been removed in setuptools 81 so pin it to 80 to avoid runtime errors, 
+    #   see https://github.com/pypa/setuptools/commit/8ba2f3829a8aae66165d9745bf838982dafb3f96
     pip install $pipopt -U -r requirements.txt && \
+    pip install $pipopt -U setuptools==80 && \
     pip install $pipopt -U -e .
 
 # to run the CKAN wsgi set the WORKDIR to CKAN

--- a/docker/ckan/2.10.7.Dockerfile
+++ b/docker/ckan/2.10.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/ckan:2.10.7--base
+FROM ghcr.io/alphagov/ckan:2.10.7-a-base
 
 USER root
 


### PR DESCRIPTION
Use the forked version of CKAN to fix an issue with the SMTP server connections due to Amazon adopting stricter stricter SNI (Server Name Indication) validation.

Also had to pin setuptools to 80 as there is a breaking change for versions > 80 which affect the core CKAN code.

Finally dropped the build of the AMD64 image as we are now running ARM64 images on the EKS cluster.