### PR TITLE
Update dgu organisations index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -e .
+          # setuptools pkg_resources has been removed in setuptools 81 so pin it to 80 to avoid runtime errors, 
+          #   see https://github.com/pypa/setuptools/commit/8ba2f3829a8aae66165d9745bf838982dafb3f96
+          pip install setuptools==80
       - name: Install dev requirements
         run: |
           pip install -r dev-requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alphagov/ckan:2.10.7--base
+      image: ghcr.io/alphagov/ckan:2.10.7-a-base
       options: --user root
     services:
       solr:

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -33,5 +33,7 @@ build_types:
     - *app_ckan
 
 runs_on:
+  - runner_type: ubuntu-latest
+    arch: amd64
   - runner_type: ubuntu-24.04-arm
     arch: arm64

--- a/ckanext/datagovuk/lib/cli.py
+++ b/ckanext/datagovuk/lib/cli.py
@@ -23,6 +23,10 @@ from ckanext.harvest.model import define_harvester_tables
 from ckanext.harvest.plugin import _create_harvest_source_object
 
 
+DGU_ORGANISATIONS_ID = "dgu_organisations_2"
+ROWS_TO_RETRIEVE = 3000
+
+
 def get_commands():
     return [datagovuk]
 
@@ -373,7 +377,7 @@ def reindex_recent(context):
 #
 # curl -g "http://$CKAN_SOLR_URL/solr/ckan/update?commit=true" \
 #     -H 'Content-Type: application/json' \
-#     -d '{"delete":{"query":"site_id:dgu_organisations%20AND%20name:org-name"}}'
+#     -d '{"delete":{"query":"site_id:<DGU_ORGANISATIONS_ID>%20AND%20name:org-name"}}'
 ###
 @datagovuk.command()
 @pass_context
@@ -395,7 +399,7 @@ def reindex_organisations(context):
     solr = pysolr.Solr(os.getenv('CKAN_SOLR_URL'), always_commit=True, timeout=10)
     solr.ping()
 
-    existing_organisations = [r.get('name') for r in solr.search("*", fq="(site_id:dgu_organisations)", rows=3000)]
+    existing_organisations = [r.get('name') for r in solr.search("*", fq=f"(site_id:{DGU_ORGANISATIONS_ID})", rows=ROWS_TO_RETRIEVE)]
     organisations = []
     counter = 0
 
@@ -406,7 +410,7 @@ def reindex_organisations(context):
         counter += 1
         print(f'{counter} - adding organisation {org.name}')
         data = {
-            "site_id": "dgu_organisations",
+            "site_id": DGU_ORGANISATIONS_ID,
             "id": org.id,
             "title": org.title,
             "name": org.name,
@@ -426,7 +430,7 @@ def reindex_organisations(context):
     if organisations:
         solr.add(organisations)
 
-    results = solr.search("*", fq="(site_id:dgu_organisations)", rows=3000)
+    results = solr.search("*", fq=f"(site_id:{DGU_ORGANISATIONS_ID})", rows=ROWS_TO_RETRIEVE)
 
     print(f"Added {len(organisations)} organisations, total number = {len(results)}")
 


### PR DESCRIPTION
The organisations index is broken on production, having over 5000 entries, rather than purging it which can result in some downtime for the directory search, I've taken the approach of creating a new index from which we can run the reindexing on and then updating datagovuk_find app to use the new index. This will minimise any downtime.

Also in thie PR is the reintroduction of the amd64 image build, this was necessary because the CI tests need to use a postgis enabled database, unfortunately there are no arm64 builds available yet from the official postgis org.

These changes were tested on Integration.

https://cddodatamarketplace.atlassian.net/browse/DGUK-433