### PR TITLE
feat: add --verbose flag

### DIFF
--- a/bin/python_scripts/check_links.py
+++ b/bin/python_scripts/check_links.py
@@ -327,6 +327,7 @@ def run(
     reindex_path: str,
     mode: str,
     limit: int | None = None,
+    verbose: bool = False,
 ) -> None:
 
     # **NOTE**
@@ -354,7 +355,8 @@ def run(
         for future in as_completed(futures):
             try:
                 result = future.result()
-                reporter.write(result)
+                if verbose or result.to_delete:
+                    reporter.write(result)
                 logger.info(
                     f"Checked resource: {result.row.resource_id} - url: {result.row.url}- outcome: {result.category}"
                 )
@@ -393,6 +395,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="limit the number of resource URLs fetched from the database (default: no limit)",
     )
     parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="write all checked resources to the CSV report (default: only deleted resources)",
+    )
+    parser.add_argument(
         "--output-dir",
         default=".",
         help="directory for CSV report and reindex list (default: current directory). "
@@ -414,6 +422,7 @@ def main(argv: list[str] | None = None) -> int:
     logger.info(f"limit: {args.limit}")
     logger.info(f"report path: {report_path}")
     logger.info(f"reindex path: {reindex_path}")
+    logger.info(f"verbose: {args.verbose}")
     logger.info(f"workers: {WORKERS}, http_timeout: {HTTP_TIMEOUT}")
 
     dsn = os.environ.get("POSTGRES_URL")
@@ -429,6 +438,7 @@ def main(argv: list[str] | None = None) -> int:
             reindex_path=reindex_path,
             mode=args.mode,
             limit=args.limit,
+            verbose=args.verbose,
         )
     return 0
 

--- a/bin/python_scripts/script-runbook.md
+++ b/bin/python_scripts/script-runbook.md
@@ -32,6 +32,8 @@ To update db instead of `--mode dry-run` use `--mode live`.
 | Flag | Required | Default | Purpose |
 |---|---|---|---|
 | `--mode` | no | `dry-run` | `dry-run` reports only; `live` marks 404/410 resources deleted |
+| `--limit` | no | no limit | limit number of resource URLs fetched from db — useful for sanity-checking a small batch |
+| `--verbose` | no | off | write all checked resources to the CSV report (default: only resources marked for deletion) |
 | `--output-dir` | no | `.` (cwd) | directory for the CSV report and reindex list |
 
 Filenames are module-level constants (`LOG_FILE` = `check_links.log`, `REPORT_FILE` = `check_links_report_{ts}.csv`, `REINDEX_FILE` = `packages_to_reindex_{ts}.txt`). 


### PR DESCRIPTION
Defaults to false

- If no flag passed then only deleted resources written to the csv report
- If flag is passed (no value after flag required) it sets to true and all resources checked written to csv report

Also added a note to script runbook about --limit flag which wasn't documented.