### PR TITLE
feat: sliding window

### DIFF
--- a/bin/python_scripts/check_links.py
+++ b/bin/python_scripts/check_links.py
@@ -327,6 +327,7 @@ def run(
     reindex_path: str,
     mode: str,
     limit: int | None = None,
+    verbose: bool = False,
 ) -> None:
 
     # **NOTE**
@@ -354,7 +355,8 @@ def run(
         for future in as_completed(futures):
             try:
                 result = future.result()
-                reporter.write(result)
+                if verbose or result.to_delete:
+                    reporter.write(result)
                 logger.info(
                     f"Checked resource: {result.row.resource_id} - url: {result.row.url}- outcome: {result.category}"
                 )
@@ -393,6 +395,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="limit the number of resource URLs fetched from the database (default: no limit)",
     )
     parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="write all checked resources to the CSV report (default: only deleted resources)",
+    )
+    parser.add_argument(
         "--output-dir",
         default=".",
         help="directory for CSV report and reindex list (default: current directory). "
@@ -414,6 +422,7 @@ def main(argv: list[str] | None = None) -> int:
     logger.info(f"limit: {args.limit}")
     logger.info(f"report path: {report_path}")
     logger.info(f"reindex path: {reindex_path}")
+    logger.info(f"verbose: {args.verbose}")
     logger.info(f"workers: {WORKERS}, http_timeout: {HTTP_TIMEOUT}")
 
     dsn = os.environ.get("POSTGRES_URL")
@@ -429,6 +438,7 @@ def main(argv: list[str] | None = None) -> int:
             reindex_path=reindex_path,
             mode=args.mode,
             limit=args.limit,
+            verbose=args.verbose,
         )
     return 0
 

--- a/bin/python_scripts/check_links.py
+++ b/bin/python_scripts/check_links.py
@@ -17,10 +17,11 @@ import logging
 import os
 import sys
 from collections import defaultdict, deque
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
+from itertools import islice
 from urllib.parse import urlsplit
 
 import psycopg2
@@ -34,9 +35,11 @@ REINDEX_FILE = "packages_to_reindex_{timestamp}.txt"
 USER_AGENT = "data.gov.uk-link-checker/1.0 (+https://www.data.gov.uk)"
 HTTP_TIMEOUT = (5, 5)  # (connect, read) seconds
 WORKERS = 50
+MAX_INFLIGHT = WORKERS * 4
 HEAD_FALLBACK_STATUSES = {400, 403, 405, 501}
 
 REPORT_HEADERS = [
+    "datagovuk-url",
     "package-id",
     "package-name",
     "resource-id",
@@ -139,10 +142,10 @@ def session_factory(
     session = requests.Session()
     session.headers.update({"User-Agent": USER_AGENT, "Accept": "*/*"})
     retry = Retry(
-        total=3,
-        status_forcelist=[429, 500, 502, 503, 504],
+        total=1,
+        status_forcelist=[500, 502, 503, 504],
         allowed_methods=["HEAD", "GET"],
-        backoff_factor=1,
+        backoff_factor=0.5,
         respect_retry_after_header=True,
     )
     adapter = HTTPAdapter(
@@ -301,6 +304,7 @@ class Reporter:
     def write(self, result: CheckResult) -> None:
         self._writer.writerow(
             {
+                "datagovuk-url": f"https://www.data.gov.uk/dataset/{result.row.package_id}/{result.row.package_name}",
                 "package-id": result.row.package_id,
                 "package-name": result.row.package_name,
                 "resource-id": result.row.resource_id,
@@ -330,13 +334,6 @@ def run(
     verbose: bool = False,
 ) -> None:
 
-    # **NOTE**
-    # This loads full result set in memory. pool.submit also queues all futures upfront.
-    # This will result in a fair amount of memory being allocated. Some tests were done
-    # locally with dummy data which isn't a substitute for testing with real data
-    # Once tested with real data, if there are issues, look into processing data in
-    # chunks
-
     rows_from_db = repository.fetch_resources(limit)
     rows = interleave_rows_by_host(rows_from_db)
     logger.info(f"loaded {len(rows)} resources")
@@ -351,23 +348,36 @@ def run(
         Reporter(report_path) as reporter,
         ThreadPoolExecutor(max_workers=WORKERS) as pool,
     ):
-        futures = [pool.submit(check_task, r, session) for r in rows]
-        for future in as_completed(futures):
-            try:
-                result = future.result()
-                if verbose or result.to_delete:
-                    reporter.write(result)
-                logger.info(
-                    f"Checked resource: {result.row.resource_id} - url: {result.row.url}- outcome: {result.category}"
-                )
-                if result.to_delete:
-                    to_reindex.add(result.row.package_id)
-                    if mode == "live":
-                        repository.mark_resource_deleted(
-                            result.row.resource_id, result.row.package_id
-                        )
-            except Exception as e:
-                logger.exception("URL check task failed")
+        row_iter = iter(rows)
+        inflight: set = set()
+
+        # grab first MAX_INFLIGHT rows to start process
+        for row in islice(row_iter, MAX_INFLIGHT):
+            inflight.add(pool.submit(check_task, row, session))
+
+        while inflight:
+            # blocks until ≥1 future complete - done is the completed and inflight is the still pending
+            done, inflight = wait(inflight, return_when=FIRST_COMPLETED)
+            for future in done:
+                try:
+                    result = future.result()
+                    if verbose or result.to_delete:
+                        reporter.write(result)
+                    logger.info(
+                        f"Checked resource: {result.row.resource_id} - url: {result.row.url} - outcome: {result.category}"
+                    )
+                    if result.to_delete:
+                        to_reindex.add(result.row.package_id)
+                        if mode == "live":
+                            repository.mark_resource_deleted(
+                                result.row.resource_id, result.row.package_id
+                            )
+                except Exception:
+                    logger.exception("URL check task failed")
+                # as each future completes, add one to top up the pool
+                next_row = next(row_iter, None)
+                if next_row is not None:
+                    inflight.add(pool.submit(check_task, next_row, session))
 
     with open(reindex_path, "w", encoding="utf-8") as f:
         for package_id in sorted(to_reindex):

--- a/bin/python_scripts/script-runbook.md
+++ b/bin/python_scripts/script-runbook.md
@@ -32,6 +32,8 @@ To update db instead of `--mode dry-run` use `--mode live`.
 | Flag | Required | Default | Purpose |
 |---|---|---|---|
 | `--mode` | no | `dry-run` | `dry-run` reports only; `live` marks 404/410 resources deleted |
+| `--limit` | no | no limit | limit number of resource URLs fetched from db — useful for sanity-checking a small batch |
+| `--verbose` | no | off | write all checked resources to the CSV report (default: only resources marked for deletion) |
 | `--output-dir` | no | `.` (cwd) | directory for the CSV report and reindex list |
 
 Filenames are module-level constants (`LOG_FILE` = `check_links.log`, `REPORT_FILE` = `check_links_report_{ts}.csv`, `REINDEX_FILE` = `packages_to_reindex_{ts}.txt`). 


### PR DESCRIPTION
make script a bit more memory friendly by using sliding window over result rows and keeping pool of futures to process at around 200 futures in pool at any time.

Also scaled back retries count and interval. risk of rate limiting hosts slipping the net, but trade that off against getting an initial run done in reasonable time.

Ran local test with real data from earlier snapshot of production datasets and resources.

Using docker image with 4gb ram allocated ran in 4.5 hours with around 4% of urls rate limited by hosts, so won't have accurate results for those urls (approx 8k urls).

The 429s were clustered around 6 domains, so recommend to proceed with this and if required another following pr can address better handling of those hosts.

Also added a new column to csv output showing data.gov.uk page url for package/dataset.