### PR TITLE
Upload check links reports to s3

### DIFF
--- a/bin/python_scripts/check_links.py
+++ b/bin/python_scripts/check_links.py
@@ -29,6 +29,9 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from lib.s3 import CkanOutputBucket
+
+
 LOG_FILE = "check_links.log"
 REPORT_FILE = "check_links_report_{timestamp}.csv"
 REINDEX_FILE = "packages_to_reindex_{timestamp}.txt"
@@ -375,6 +378,16 @@ class Reporter:
         self._fh.flush()
 
 
+def upload_to_s3(logger, reindex_path, report_path):
+    bucket = CkanOutputBucket()
+    bucket.upload_to_s3(reindex_path, "check_links")
+    logger.info(f"uploaded {reindex_path} to S3 bucket {bucket.bucket.name}")
+    bucket.upload_to_s3(report_path, "check_links")
+    logger.info(f"uploaded {report_path} to S3 bucket {bucket.bucket.name}")
+    logger.info("=== check_links/ ls")
+    bucket.get_s3_ls(path="check_links/")
+
+
 def run(
     *,
     logger: logging.Logger,
@@ -502,6 +515,8 @@ def main(argv: list[str] | None = None) -> int:
             limit=args.limit,
             verbose=args.verbose,
         )
+    
+    upload_to_s3(logger, reindex_path, report_path)
     return 0
 
 

--- a/bin/python_scripts/check_links_download.py
+++ b/bin/python_scripts/check_links_download.py
@@ -1,0 +1,17 @@
+import sys
+
+from lib.s3 import CkanOutputBucket
+
+
+def main() -> int:
+    bucket = CkanOutputBucket()
+    # check_links/ should match the path in the s3 ckan-output bucket
+    for file_path in bucket.get_s3_ls(path="check_links/"):
+        # /check_links should match the mount path for check-links-output-nginx-deployment.yaml in govuk-dgu-charts repo
+        bucket.download_from_s3(file_path, target_dir="/check_links")
+        print(f"downloaded {file_path} from S3 bucket {bucket.bucket.name}")
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/python_scripts/lib/s3.py
+++ b/bin/python_scripts/lib/s3.py
@@ -28,5 +28,10 @@ class CkanOutputBucket(object):
         self.bucket.upload_file(path, s3_path)
 
 
-    def download_from_s3(self, s3_path):
-        self.bucket.download_file(s3_path)
+    def download_from_s3(self, s3_path, target_dir=None):
+        target_path = s3_path
+        if target_dir:
+            filename = s3_path.split("/")[-1]
+            target_path = target_dir + "/" + filename
+
+        self.bucket.download_file(s3_path, target_path)

--- a/bin/python_scripts/lib/s3.py
+++ b/bin/python_scripts/lib/s3.py
@@ -1,0 +1,32 @@
+import boto3
+import os
+import re
+
+
+class CkanOutputBucket(object):
+    def __init__(self):
+        bucket_name = os.environ.get('CKAN_OUTPUT_BUCKET_NAME')
+        if not bucket_name:
+            raise Exception("CKAN_OUTPUT_BUCKET_NAME environment variable is not set")
+
+        s3 = boto3.resource('s3')
+        self.bucket = s3.Bucket(bucket_name)
+
+    def get_s3_ls(self, path=None):
+        filenames = []
+        for obj in self.bucket.objects.all():
+            if path and not re.match(path, obj.key):
+                continue
+            filenames.append(obj.key)
+        return filenames
+
+    def upload_to_s3(self, path, s3_path=None):
+        if s3_path:
+            s3_path = s3_path + "/" + path.split("/")[-1]
+        else:
+            s3_path = path.split("/")[-1]
+        self.bucket.upload_file(path, s3_path)
+
+
+    def download_from_s3(self, s3_path):
+        self.bucket.download_file(s3_path)

--- a/bin/python_scripts/script-runbook.md
+++ b/bin/python_scripts/script-runbook.md
@@ -5,6 +5,10 @@
 - Set environment variable `POSTGRES_URL`
 - Value from `docker/.env.example` == `postgresql://ckan:ckan@db/ckan`
 
+Reports are uploaded to an s3 bucket if the environment variable is set, this is needed to be able to publish the reports 
+- Set environment variable `CKAN_OUTPUT_BUCKET_NAME`
+- Value set as `govuk-ckan-output-<integration|staging|production>`
+
 ***
 
 ### Link checking


### PR DESCRIPTION
Add upload of reports to s3 after the check_links scripts completes and a download of reports on s3 so that they can be published.

This has been successfully tested on Integration and Staging running multiple CKAN pods.

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?selectedIssue=DGUK-527