### PR TITLE
feat: split dns and connection refused errors

### DIFF
--- a/bin/python_scripts/check_links.py
+++ b/bin/python_scripts/check_links.py
@@ -86,6 +86,8 @@ class Category(StrEnum):
     SERVER_ERROR = "SERVER_ERROR"
     TIMEOUT = "TIMEOUT"
     CONNECTION_ERROR = "CONNECTION_ERROR"
+    DNS_ERROR = "DNS_ERROR"
+    CONNECTION_REFUSED = "CONNECTION_REFUSED"
     OTHER_ERROR = "OTHER_ERROR"
 
 
@@ -118,7 +120,34 @@ class CheckResult:
 
     @property
     def to_delete(self) -> bool:
-        return self.category in {Category.NOT_FOUND, Category.GONE}
+        return self.category in {
+            Category.NOT_FOUND,
+            Category.GONE,
+            Category.DNS_ERROR,
+            Category.CONNECTION_REFUSED,
+        }
+
+
+def classify_connection_error(exc: ConnectionError) -> tuple[Category, str]:
+    """Try to disambiguate requests.ConnectionError 
+    into DNS error or refused, and if not return original 
+    generic ConnectionError
+    """
+    detail = str(exc)
+    text = detail.lower()
+    if any(
+        s in text
+        for s in (
+            "name or service not known",
+            "nodename nor servname",
+            "failed to resolve",
+            "name resolution",
+        )
+    ):
+        return Category.DNS_ERROR, detail
+    if "connection refused" in text:
+        return Category.CONNECTION_REFUSED, detail
+    return Category.CONNECTION_ERROR, detail
 
 
 def classify_response(
@@ -128,7 +157,7 @@ def classify_response(
         case (_, requests.Timeout()):
             return Category.TIMEOUT, str(exc)
         case (_, requests.ConnectionError()):
-            return Category.CONNECTION_ERROR, str(exc)
+            return classify_connection_error(exc)
         case (_, BaseException()):
             return Category.OTHER_ERROR, str(exc)
         case (None, None):
@@ -155,11 +184,12 @@ def session_factory(
     session = requests.Session()
     session.headers.update({"User-Agent": USER_AGENT, "Accept": "*/*"})
     retry = Retry(
-        total=1,
+        total=3,
         status_forcelist=[500, 502, 503, 504],
         allowed_methods=["HEAD", "GET"],
         backoff_factor=0.5,
         respect_retry_after_header=True,
+        raise_on_status=False,
     )
     adapter = HTTPAdapter(
         max_retries=retry,

--- a/bin/python_scripts/tests/test_check_links.py
+++ b/bin/python_scripts/tests/test_check_links.py
@@ -16,6 +16,7 @@ from python_scripts.check_links import (
     classify_response,
     host_key,
     interleave_rows_by_host,
+    session_factory,
 )
 
 
@@ -68,6 +69,15 @@ def stub_result(
     )
 
 
+def _stub_dns_connection_error() -> requests.ConnectionError:
+    # stub error requests raises when the host fails to resolve.
+    return requests.ConnectionError(
+        "HTTPSConnectionPool(host='no-such-host.example', port=443): Max retries "
+        "exceeded (Caused by NameResolutionError(\"Failed to resolve "
+        "'no-such-host.example' ([Errno -2] Name or service not known)\"))"
+    )
+
+
 @pytest.mark.parametrize(
     "status, exc, expected_cat",
     [
@@ -81,6 +91,13 @@ def stub_result(
         (503, None, Category.SERVER_ERROR),
         (None, requests.Timeout("timeout"), Category.TIMEOUT),
         (None, requests.ConnectionError("connection error"), Category.CONNECTION_ERROR),
+        (None, _stub_dns_connection_error(), Category.DNS_ERROR),
+        (
+            None,
+            requests.ConnectionError(ConnectionRefusedError(111, "Connection refused")),
+            Category.CONNECTION_REFUSED,
+        ),
+        (None, requests.exceptions.SSLError("bad handshake"), Category.CONNECTION_ERROR),
         (None, ValueError("some other error"), Category.OTHER_ERROR),
         (None, None, Category.OTHER_ERROR),
     ],
@@ -103,6 +120,8 @@ def test_classify_maps_http_and_exceptions_to_categories(status, exc, expected_c
         (Category.SERVER_ERROR, False),
         (Category.TIMEOUT, False),
         (Category.CONNECTION_ERROR, False),
+        (Category.DNS_ERROR, True),
+        (Category.CONNECTION_REFUSED, True),
         (Category.OTHER_ERROR, False),
     ],
 )
@@ -202,6 +221,30 @@ def test_check_task_uses_head_status(make_row):
         timeout=HTTP_TIMEOUT,
         allow_redirects=True,
     )
+
+
+def test_check_task_classifies_server_error_with_status(make_row):
+    session = requests.Session()
+    head_response = MagicMock()
+    head_response.status_code = 503
+    head_response.__enter__.return_value = head_response
+    head_response.__exit__.return_value = False
+    session.head = Mock(return_value=head_response)
+
+    result = check_task(make_row("res-id", "https://opendata.gov.uk"), session)
+
+    assert result.http_status == 503
+    assert result.category is Category.SERVER_ERROR
+
+
+def test_session_factory_retry_does_not_raise_on_status():
+    # Retry must return the final 5xx response rather than raising RetryError,
+    # otherwise check_task loses the status code and misclassifies it as
+    # OTHER_ERROR instead of SERVER_ERROR.
+    session = session_factory()
+    retry = session.get_adapter("https://opendata.gov.uk").max_retries
+    assert retry.raise_on_status is False
+    assert set(retry.status_forcelist) == {500, 502, 503, 504}
 
 
 def test_check_task_falls_back_to_get_for_head_fallback_status(make_row):


### PR DESCRIPTION
This PR covers the following:

1. split dns and connection refused out from generic connection errors or by checking exception chain from requests. 
2. Increased number of retries 
3. Fixed bug on retry flag that swallowed final errors status codes for force retry list errors. This caused status code to not be recorded in csv for 5xx range errors, in verbose mode.