### PR TITLE
feat: to enable easy local runs of the check links script

### DIFF
--- a/bin/python_scripts/check_links.py
+++ b/bin/python_scripts/check_links.py
@@ -512,6 +512,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="directory for CSV report and reindex list (default: current directory). "
         "Log file is always written to the current directory.",
     )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        default=False,
+        help="Skips pushing output files to S3, so local testing easier",
+    )
     return parser.parse_args(argv)
 
 
@@ -530,6 +536,7 @@ def main(argv: list[str] | None = None) -> int:
     logger.info(f"reindex path: {reindex_path}")
     logger.info(f"verbose: {args.verbose}")
     logger.info(f"workers: {WORKERS}, http_timeout: {HTTP_TIMEOUT}")
+    logger.info(f"local: {args.local}")
 
     dsn = os.environ.get("POSTGRES_URL")
     if not dsn:
@@ -546,8 +553,10 @@ def main(argv: list[str] | None = None) -> int:
             limit=args.limit,
             verbose=args.verbose,
         )
-    
-    upload_to_s3(logger, reindex_path, report_path)
+
+    if not args.local:
+        upload_to_s3(logger, reindex_path, report_path)
+
     return 0
 
 

--- a/bin/python_scripts/conftest.py
+++ b/bin/python_scripts/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# this is so the `lib` package as a top-level package (e.g. `from lib.s3 import
+# CkanOutputBucket` works in check_links.py, the same way the scripts are run 
+# from this directory) works in pytest, otherwise we get import error when 
+# running tests
+sys.path.insert(0, os.path.dirname(__file__))

--- a/bin/python_scripts/script-runbook.md
+++ b/bin/python_scripts/script-runbook.md
@@ -5,9 +5,12 @@
 - Set environment variable `POSTGRES_URL`
 - Value from `docker/.env.example` == `postgresql://ckan:ckan@db/ckan`
 
-Reports are uploaded to an s3 bucket if the environment variable is set, this is needed to be able to publish the reports 
+Reports are uploaded to an s3 bucket and the following env variable will need to be set otherwise an exception will be thrown. This is needed to be able to publish the reports 
+
 - Set environment variable `CKAN_OUTPUT_BUCKET_NAME`
 - Value set as `govuk-ckan-output-<integration|staging|production>`
+
+If testing locally you can skip wth S3 bucket output by passing the flag `--local`
 
 ***
 
@@ -39,6 +42,7 @@ To update db instead of `--mode dry-run` use `--mode live`.
 | `--limit` | no | no limit | limit number of resource URLs fetched from db — useful for sanity-checking a small batch |
 | `--verbose` | no | off | write all checked resources to the CSV report (default: only resources marked for deletion) |
 | `--output-dir` | no | `.` (cwd) | directory for the CSV report and reindex list |
+| `--local` | no | False | If set will skip the attempt to write to output files to S3 |
 
 Filenames are module-level constants (`LOG_FILE` = `check_links.log`, `REPORT_FILE` = `check_links_report_{ts}.csv`, `REINDEX_FILE` = `packages_to_reindex_{ts}.txt`). 
 The CSV report and reindex list are timestamped per run and placed in current directory or `--output-dir`.
@@ -117,7 +121,7 @@ Requires test data in the db (run `ckan datagovuk create-dgu-test-data`):
 
 ```bash
 export POSTGRES_URL=postgresql://ckan:ckan@db/ckan
-python check_links.py
+python check_links.py --local
 ```
 
 You can add the arg: 


### PR DESCRIPTION
 Addition of S3 upload get's in the way of local testing of script
 
Solution is to add a --local flag with defaults to False, such that normal operation in live carries on as normal but by passing flag we skip S3 upload.
 
Also added conftest which fixes test breakages due to lib.s3 import errors. 
 
 