### PR TITLE
DGUK-621 Publisher emails associated with broken resource urls

### DIFF
--- a/bin/python_scripts/emails_of_broken_links.py
+++ b/bin/python_scripts/emails_of_broken_links.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import csv
+import os
+import sys
+import logging
+
+import psycopg2
+
+POSTGRES_URL = os.environ.get('POSTGRES_URL')
+
+logger = logging.getLogger(__name__)
+
+
+def setup_logging():
+    _format = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    logger.setLevel(logging.INFO)
+    c_handler = logging.StreamHandler()
+    c_handler.setFormatter(_format)
+    logger.addHandler(c_handler)
+
+
+def read_resource_ids(csv_path):
+    ids = []
+    with open(csv_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            resource_id = row.get('resource-id', '').strip()
+            if resource_id:
+                ids.append(resource_id)
+    return ids
+
+
+def query_publishers(connection, resource_ids):
+    cursor = connection.cursor()
+    placeholders = ', '.join(['%s'] * len(resource_ids))
+
+    sql = """
+    SELECT DISTINCT u.email, g.name AS organisation
+    FROM "user" u
+    JOIN member m ON u.id = m.table_id AND m.table_name = 'user' AND m.state = 'active'
+    JOIN "group" g ON g.id = m.group_id
+    JOIN package p ON p.owner_org = g.id
+    JOIN resource r ON r.package_id = p.id AND r.state = 'active'
+    WHERE r.id IN ({ids})
+      AND u.state = 'active'
+    ORDER BY g.name, u.email
+    """.format(ids=placeholders)
+
+    cursor.execute(sql, resource_ids)
+    return cursor.fetchall()
+
+
+def main():
+    setup_logging()
+
+    if len(sys.argv) < 2:
+        print('Usage: python emails_of_broken_links.py <resource_ids.csv>')
+        sys.exit(1)
+
+    csv_path = sys.argv[1]
+
+    connection = psycopg2.connect(POSTGRES_URL)
+
+    logger.info('Reading resource IDs from %s', csv_path)
+    resource_ids = read_resource_ids(csv_path)
+    logger.info('Found %d resource IDs', len(resource_ids))
+
+    logger.info('Querying database...')
+    rows = query_publishers(connection, resource_ids)
+    logger.info('Found %d results', len(rows))
+
+    if not rows:
+        logger.info('No results found.')
+        return
+
+    output_path = '/check_links/publisher_emails.csv'
+    with open(output_path, 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(['email', 'organisation'])
+        writer.writerows(rows)
+
+    logger.info('Report written to %s', output_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/python_scripts/publisher_emails_of_broken_links.py
+++ b/bin/python_scripts/publisher_emails_of_broken_links.py
@@ -20,41 +20,39 @@ def setup_logging():
     logger.addHandler(c_handler)
 
 
-def read_resource_ids(csv_path):
-    ids = []
+def read_org_names(csv_path):
+    org_names = []
     with open(csv_path, 'r') as f:
         reader = csv.DictReader(f)
         for row in reader:
-            resource_id = row.get('resource-id', '').strip()
-            if resource_id:
-                ids.append(resource_id)
-    return ids
+            org_name = row.get('org-name', '').strip()
+            if org_name:
+                org_names.append(org_name)
+    return org_names
 
 
-def query_active_publisher_emails(connection, resource_ids):
+def query_active_publisher_emails(connection, group_names):
     cursor = connection.cursor()
-    placeholders = ', '.join(['%s'] * len(resource_ids))
+    placeholders = ', '.join(['%s'] * len(group_names))
 
     sql = """
     SELECT DISTINCT u.email, g.name AS organisation
     FROM "user" u
     JOIN member m ON u.id = m.table_id AND m.table_name = 'user' AND m.state = 'active'
     JOIN "group" g ON g.id = m.group_id
-    JOIN package p ON p.owner_org = g.id
-    JOIN resource r ON r.package_id = p.id AND r.state = 'active'
-    WHERE r.id IN ({ids})
-      AND u.state = 'active'
+    AND g.name IN ({group_names})
+    AND u.state = 'active'
     ORDER BY g.name, u.email
-    """.format(ids=placeholders)
+    """.format(group_names=placeholders)
 
-    cursor.execute(sql, resource_ids)
+    cursor.execute(sql, group_names)
     return cursor.fetchall()
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description='Get publisher emails associated with broken resource links/urls'
     )
-    parser.add_argument("--csv_path", "-c", required=True, help='Path to CSV file containing resource IDs')
+    parser.add_argument("--csv_path", "-c", required=True, help='Path to CSV file containing organisation names')
     parser.add_argument("--output-dir", "-o", required=True, help='Directory to write publisher_emails.csv to')
 
     return parser.parse_args(argv)
@@ -65,15 +63,15 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parse_args(argv)
 
-    logger.info('Reading resource IDs from %s', args.csv_path)
-    resource_ids = read_resource_ids(args.csv_path)
-    logger.info('Found %d resource IDs', len(resource_ids))
+    logger.info('Reading organisation/group names from %s', args.csv_path)
+    org_names = read_org_names(args.csv_path)
+    logger.info('Found %d organisation/group names', len(org_names))
 
     logger.info('Querying database...')
     
     try:
         connection = psycopg2.connect(POSTGRES_URL)
-        rows = query_active_publisher_emails(connection, resource_ids)
+        rows = query_active_publisher_emails(connection, org_names)
     finally:
         connection.close()
 

--- a/bin/python_scripts/publisher_emails_of_broken_links.py
+++ b/bin/python_scripts/publisher_emails_of_broken_links.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import csv
 import os
 import sys
@@ -50,20 +51,25 @@ def query_active_publisher_emails(connection, resource_ids):
     cursor.execute(sql, resource_ids)
     return cursor.fetchall()
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Get publisher emails associated with broken resource links/urls'
+    )
+    parser.add_argument("--csv_path", "-c", required=True, help='Path to CSV file containing resource IDs')
+    parser.add_argument("--output-dir", "-o", required=True, help='Directory to write publisher_emails.csv to')
 
-def main():
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
     setup_logging()
 
-    if len(sys.argv) < 2:
-        print('Usage: python emails_of_broken_links.py <resource_ids.csv>')
-        sys.exit(1)
-
-    csv_path = sys.argv[1]
+    args = parse_args(argv)
 
     connection = psycopg2.connect(POSTGRES_URL)
 
-    logger.info('Reading resource IDs from %s', csv_path)
-    resource_ids = read_resource_ids(csv_path)
+    logger.info('Reading resource IDs from %s', args.csv_path)
+    resource_ids = read_resource_ids(args.csv_path)
     logger.info('Found %d resource IDs', len(resource_ids))
 
     logger.info('Querying database...')
@@ -74,7 +80,7 @@ def main():
         logger.info('No results found.')
         return
 
-    output_path = '/check_links/publisher_emails.csv'
+    output_path = os.path.join(args.output_dir, 'publisher_emails.csv')
     with open(output_path, 'w', newline='') as f:
         writer = csv.writer(f)
         writer.writerow(['email', 'organisation'])

--- a/bin/python_scripts/publisher_emails_of_broken_links.py
+++ b/bin/python_scripts/publisher_emails_of_broken_links.py
@@ -31,7 +31,7 @@ def read_resource_ids(csv_path):
     return ids
 
 
-def query_publishers(connection, resource_ids):
+def query_active_publisher_emails(connection, resource_ids):
     cursor = connection.cursor()
     placeholders = ', '.join(['%s'] * len(resource_ids))
 
@@ -67,7 +67,7 @@ def main():
     logger.info('Found %d resource IDs', len(resource_ids))
 
     logger.info('Querying database...')
-    rows = query_publishers(connection, resource_ids)
+    rows = query_active_publisher_emails(connection, resource_ids)
     logger.info('Found %d results', len(rows))
 
     if not rows:

--- a/bin/python_scripts/publisher_emails_of_broken_links.py
+++ b/bin/python_scripts/publisher_emails_of_broken_links.py
@@ -3,7 +3,6 @@
 import argparse
 import csv
 import os
-import sys
 import logging
 
 import psycopg2
@@ -66,14 +65,18 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parse_args(argv)
 
-    connection = psycopg2.connect(POSTGRES_URL)
-
     logger.info('Reading resource IDs from %s', args.csv_path)
     resource_ids = read_resource_ids(args.csv_path)
     logger.info('Found %d resource IDs', len(resource_ids))
 
     logger.info('Querying database...')
-    rows = query_active_publisher_emails(connection, resource_ids)
+    
+    try:
+        connection = psycopg2.connect(POSTGRES_URL)
+        rows = query_active_publisher_emails(connection, resource_ids)
+    finally:
+        connection.close()
+
     logger.info('Found %d results', len(rows))
 
     if not rows:

--- a/bin/python_scripts/tests/test_publisher_emails_of_broken_links.py
+++ b/bin/python_scripts/tests/test_publisher_emails_of_broken_links.py
@@ -1,0 +1,57 @@
+
+import pytest
+import publisher_emails_of_broken_links
+from unittest.mock import patch, Mock
+
+from python_scripts.publisher_emails_of_broken_links import (
+    query_active_publisher_emails,
+    read_resource_ids
+)
+
+class TestPublisherEmailsOfBrokenLinks:
+        
+    @patch('python_scripts.publisher_emails_of_broken_links.psycopg2.connect')
+    def test_query_active_publisher_emails(self, mock_connect):
+        mock_cursor = mock_connect.cursor.return_value
+        mock_cursor.fetchall.return_value = [
+            ('publisher1@example.com', 'Organisation A'),
+            ('publisher2@example.com', 'Organisation B')
+        ]
+        mock_cursor.execute.return_value = 123
+        mock_cursor.rowcount = 4
+
+        result = query_active_publisher_emails(mock_connect, ['resource-1', 'resource-2'])
+
+        assert result == [
+            ('publisher1@example.com', 'Organisation A'),
+            ('publisher2@example.com', 'Organisation B')
+        ]
+
+        mock_cursor.execute.assert_called_once_with("""
+    SELECT DISTINCT u.email, g.name AS organisation
+    FROM "user" u
+    JOIN member m ON u.id = m.table_id AND m.table_name = 'user' AND m.state = 'active'
+    JOIN "group" g ON g.id = m.group_id
+    JOIN package p ON p.owner_org = g.id
+    JOIN resource r ON r.package_id = p.id AND r.state = 'active'
+    WHERE r.id IN (%s, %s)
+      AND u.state = 'active'
+    ORDER BY g.name, u.email
+    """, ['resource-1', 'resource-2'])
+
+    @patch('python_scripts.publisher_emails_of_broken_links.psycopg2.connect')
+    def test_read_resource_ids(self, mock_connect, tmp_path):
+        mock_cursor = mock_connect.cursor.return_value
+        mock_cursor.fetchall.return_value = [
+            ('publisher1@example.com', 'Organisation A'),
+            ('publisher2@example.com', 'Organisation B')
+        ]
+        mock_cursor.execute.return_value = 123
+        mock_cursor.rowcount = 4
+        csv = tmp_path / "test_data.csv"
+
+        csv.write_text("resource-id,organisation\nresource-1,Organisation A\nresource-2,Organisation B\n")
+
+        result = read_resource_ids(csv)
+
+        assert result == ['resource-1', 'resource-2']

--- a/bin/python_scripts/tests/test_publisher_emails_of_broken_links.py
+++ b/bin/python_scripts/tests/test_publisher_emails_of_broken_links.py
@@ -5,7 +5,8 @@ from unittest.mock import patch, Mock
 
 from python_scripts.publisher_emails_of_broken_links import (
     query_active_publisher_emails,
-    read_resource_ids
+    read_resource_ids,
+    main
 )
 
 class TestPublisherEmailsOfBrokenLinks:
@@ -55,3 +56,22 @@ class TestPublisherEmailsOfBrokenLinks:
         result = read_resource_ids(csv)
 
         assert result == ['resource-1', 'resource-2']
+    
+    @patch('python_scripts.publisher_emails_of_broken_links.psycopg2.connect')
+    def test_query_results_outputted_to_csv(self, mock_connect, tmp_path):
+        mock_cursor = mock_connect.return_value.cursor.return_value
+        mock_cursor.fetchall.return_value = [
+            ('publisher1@example.com', 'Organisation A')
+        ]
+        mock_cursor.execute.return_value = 123
+        mock_cursor.rowcount = 4
+
+        csv = tmp_path / "test_data.csv"
+        csv.write_text("resource-id,organisation\nresource-1,Organisation A\nresource-2,Organisation B\n")
+
+        main(argv=['--csv_path', str(csv), '--output-dir', str(tmp_path)])
+
+        output_csv = tmp_path / "publisher_emails.csv"
+        assert output_csv.exists()
+        assert output_csv.read_text() == "email,organisation\npublisher1@example.com,Organisation A\n"
+        

--- a/bin/python_scripts/tests/test_publisher_emails_of_broken_links.py
+++ b/bin/python_scripts/tests/test_publisher_emails_of_broken_links.py
@@ -10,7 +10,6 @@ from python_scripts.publisher_emails_of_broken_links import (
 )
 
 class TestPublisherEmailsOfBrokenLinks:
-        
     @patch('python_scripts.publisher_emails_of_broken_links.psycopg2.connect')
     def test_query_active_publisher_emails(self, mock_connect):
         mock_cursor = mock_connect.cursor.return_value

--- a/bin/python_scripts/tests/test_publisher_emails_of_broken_links.py
+++ b/bin/python_scripts/tests/test_publisher_emails_of_broken_links.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, Mock
 
 from python_scripts.publisher_emails_of_broken_links import (
     query_active_publisher_emails,
-    read_resource_ids,
+    read_org_names,
     main
 )
 
@@ -20,7 +20,7 @@ class TestPublisherEmailsOfBrokenLinks:
         mock_cursor.execute.return_value = 123
         mock_cursor.rowcount = 4
 
-        result = query_active_publisher_emails(mock_connect, ['resource-1', 'resource-2'])
+        result = query_active_publisher_emails(mock_connect, ['Organisation A', 'Organisation B'])
 
         assert result == [
             ('publisher1@example.com', 'Organisation A'),
@@ -32,29 +32,18 @@ class TestPublisherEmailsOfBrokenLinks:
     FROM "user" u
     JOIN member m ON u.id = m.table_id AND m.table_name = 'user' AND m.state = 'active'
     JOIN "group" g ON g.id = m.group_id
-    JOIN package p ON p.owner_org = g.id
-    JOIN resource r ON r.package_id = p.id AND r.state = 'active'
-    WHERE r.id IN (%s, %s)
-      AND u.state = 'active'
+    AND g.name IN (%s, %s)
+    AND u.state = 'active'
     ORDER BY g.name, u.email
-    """, ['resource-1', 'resource-2'])
+    """, ['Organisation A', 'Organisation B'])
 
-    @patch('python_scripts.publisher_emails_of_broken_links.psycopg2.connect')
-    def test_read_resource_ids(self, mock_connect, tmp_path):
-        mock_cursor = mock_connect.cursor.return_value
-        mock_cursor.fetchall.return_value = [
-            ('publisher1@example.com', 'Organisation A'),
-            ('publisher2@example.com', 'Organisation B')
-        ]
-        mock_cursor.execute.return_value = 123
-        mock_cursor.rowcount = 4
+    def test_read_org_names(self, tmp_path):
         csv = tmp_path / "test_data.csv"
+        csv.write_text("resource-id,org-name\nresource-1,Organisation A\nresource-2,Organisation B\n")
 
-        csv.write_text("resource-id,organisation\nresource-1,Organisation A\nresource-2,Organisation B\n")
+        result = read_org_names(csv)
 
-        result = read_resource_ids(csv)
-
-        assert result == ['resource-1', 'resource-2']
+        assert result == ['Organisation A', 'Organisation B']
     
     @patch('python_scripts.publisher_emails_of_broken_links.psycopg2.connect')
     def test_query_results_outputted_to_csv(self, mock_connect, tmp_path):


### PR DESCRIPTION
Create a python script that takes a csv with a list of `org-name` containing all the HTTP 404 and 410 error-ing resource links 

It then gets the publisher email relating to the org-name via the database and **outputs** a csv containing the emails and organisation names

ℹ️ By broken resource urls, I mean the url links in the dataset returning 404 or 410 http errors during the check links cronjob 

**TODO:**
- [X] Tested in integration
- [x] Add unit tests