### PR TITLE
DGUK-641 Trim whitespace from resource url

### DIFF
--- a/bin/python_scripts/check_links.py
+++ b/bin/python_scripts/check_links.py
@@ -317,7 +317,7 @@ class Repository:
                     package_id=package_id,
                     package_name=package_name,
                     resource_id=resource_id,
-                    url=url,
+                    url=url.strip(),
                     org_name=org_name,
                     org_id=org_id,
                     resource_created=resource_created,

--- a/bin/python_scripts/tests/test_check_links.py
+++ b/bin/python_scripts/tests/test_check_links.py
@@ -11,6 +11,7 @@ from python_scripts.check_links import (
     Category,
     CheckResult,
     Reporter,
+    Repository,
     ResourceRow,
     check_task,
     classify_response,
@@ -311,3 +312,36 @@ def test_interleave_rows_by_host_preserves_order_for_single_host(make_row):
     ]
 
     assert interleave_rows_by_host(rows) == rows
+
+def test_fetch_resources_strips_whitespace_from_urls():
+    mock_connection = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.__enter__ = Mock(return_value=mock_cursor)
+    mock_connection.cursor.return_value = mock_cursor
+    mock_cursor.__iter__ = Mock(
+        return_value=iter(
+            [
+                (
+                    "package_id",
+                    "package_name",
+                    "resource_id",
+                    "  https://test.com/fake.csv  ",
+                    "org_name",
+                    "org_id",
+                    datetime(2026, 1, 1),
+                    datetime(2026, 1, 1),
+                    datetime(2026, 1, 1),
+                    datetime(2026, 1, 1),
+                    datetime(2026, 1, 1),
+                    "guid",
+                ),
+            ]
+        )
+    )
+
+    repo = Repository.__new__(Repository)
+    repo._conn = mock_connection
+
+    resource_rows = repo.fetch_resources()
+
+    assert resource_rows[0].url == "https://test.com/fake.csv"


### PR DESCRIPTION
Trim the whitespace from the resource url before running the check links task

This prevents issues when calling the resource url to check if it is a broken link or  not