### PR TITLE
Handle process s3 upload exceptions

### DIFF
--- a/bin/python_scripts/process_check_links_report.py
+++ b/bin/python_scripts/process_check_links_report.py
@@ -183,7 +183,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         upload_to_s3(logger, output_report_path)
     except Exception as e:
-        logger.warn(f"Problem uploading {output_report_path} to s3")
+        logger.warn(f"Problem uploading {output_report_path} to s3 - {str(e)}")
     return 0
 
 

--- a/bin/python_scripts/process_check_links_report.py
+++ b/bin/python_scripts/process_check_links_report.py
@@ -180,7 +180,10 @@ def main(argv: list[str] | None = None) -> int:
             set_state=args.set_state,
         )
 
-    upload_to_s3(logger, output_report_path)
+    try:
+        upload_to_s3(logger, output_report_path)
+    except Exception as e:
+        logger.warn(f"Problem uploading {output_report_path} to s3")
     return 0
 
 


### PR DESCRIPTION
Do not stop the processing if there is a problem with uploading the deletion report, there might not be any report file to upload if the job is re-run in order to start the reharvesting of the report ids.