### PR TITLE
Raise error non 200 response

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -63,7 +63,7 @@ jobs:
           echo "runs_on=$runs_on" >> "$GITHUB_OUTPUT"
           
   build_push_multiarch_image:
-    name: Build ${{ matrix.app.name }} for ${{ matrix.runs_on.arch }}
+    name: Build ${{ matrix.app.name }} for ${{ matrix.runs_on.arch }} with ${{ inputs.buildType }}
     needs: configure_builds
     strategy:
       matrix: 

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -2,7 +2,7 @@ apps:
   ckan: &app_ckan
     name: ckan
     version: "2.10.7"
-    patch: a
+    patch: b
   pycsw: &app_pycsw
     name: pycsw
     version: "2.6.1"

--- a/docker/ckan/2.10.7-base.Dockerfile
+++ b/docker/ckan/2.10.7-base.Dockerfile
@@ -14,7 +14,8 @@ ENV ckan_harvest_sha='9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-ENV ckan_spatial_sha='c4938431346b50209d7bcf89a1a0154698b9f9f2'
+# raise error on non 200 HTTP responses
+ENV ckan_spatial_sha='92e03974d9352ff2ad22686928b5594f8a7a8ad3'
 ENV ckan_spatial_fork='alphagov'
 
 RUN echo "pip install DGU extensions..." && \

--- a/docker/ckan/2.10.7-base.Dockerfile
+++ b/docker/ckan/2.10.7-base.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/ckan:2.10.7-a-core
+FROM ghcr.io/alphagov/ckan:2.10.7-b-core
 
 COPY production.ini $CKAN_CONFIG/production.ini
 # Set CKAN_INI

--- a/docker/ckan/2.10.7.Dockerfile
+++ b/docker/ckan/2.10.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/ckan:2.10.7-a-base
+FROM ghcr.io/alphagov/ckan:2.10.7-b-base
 
 USER root
 


### PR DESCRIPTION
A publisher was experiencing issues with their harvest source but the error messages in the harvest jobs errors list did not make any sense and looked like the system was broken. 
There was in fact an issue with the publishers harvest source but the correct error didn't get propagated, so updating the Spatial sha should enable the surfacing of the correct error which was a 403 response to a server request on the harvest source. 

Additionally, the github actions was updated to show which build type is running as this wasn't clear in the github actions.

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/727?selectedIssue=DGUK-763