### PR TITLE
Update spatial sha allow errored harvest object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alphagov/ckan:2.10.7-a-base
+      image: ghcr.io/alphagov/ckan:2.10.7-d-base
       options: --user root
     services:
       solr:

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -2,7 +2,7 @@ apps:
   ckan: &app_ckan
     name: ckan
     version: "2.10.7"
-    patch: c
+    patch: d
   pycsw: &app_pycsw
     name: pycsw
     version: "2.6.1"

--- a/docker/ckan/2.10.7-base.Dockerfile
+++ b/docker/ckan/2.10.7-base.Dockerfile
@@ -14,8 +14,8 @@ ENV ckan_harvest_sha='9fb44f79809a1c04dfeb0e1ca2540c5ff3cacef4'
 ENV ckan_dcat_fork='ckan'
 ENV ckan_dcat_sha='618928be5a211babafc45103a72b6aab4642e964'
 
-# add datagovuk-harvester to user-agent request headers
-ENV ckan_spatial_sha='4ed56e1cb41ded3daf8b06730e022f0f6bd8a271'
+# allow errored harvest objects to continue processing if they have not been added before
+ENV ckan_spatial_sha='6f78ee7454b5fcdf7ef11d81bb08b06e9741de70'
 ENV ckan_spatial_fork='alphagov'
 
 RUN echo "pip install DGU extensions..." && \

--- a/docker/ckan/2.10.7-base.Dockerfile
+++ b/docker/ckan/2.10.7-base.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/ckan:2.10.7-c-core
+FROM ghcr.io/alphagov/ckan:2.10.7-d-core
 
 COPY production.ini $CKAN_CONFIG/production.ini
 # Set CKAN_INI

--- a/docker/ckan/2.10.7.Dockerfile
+++ b/docker/ckan/2.10.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/ckan:2.10.7-c-base
+FROM ghcr.io/alphagov/ckan:2.10.7-d-base
 
 USER root
 


### PR DESCRIPTION
This will allow datasets to be created if they have validation errors, as sometimes the validation errors are for minor issues which shouldn't affect the publication of the dataset.

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/727?selectedIssue=DGUK-736